### PR TITLE
feat: role-based dashboard access (read-only vs admin)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,9 @@ discovery_timeout_ms = 1500
 # for the full template). Off by default; turning [auth].enabled = true
 # requires oidc.issuer/client_id/redirect_url, a session.secret (≥16 chars),
 # and at least one entry under access.allowed_{emails,domains,groups}.
+# Optionally set [auth.access.admin].allowed_{emails,domains,groups} to
+# split write access from read-only — everyone who signs in but isn't on
+# the admin list is read-only.
 ```
 
 Env knobs:
@@ -172,9 +175,18 @@ Destructive verbs require `?confirm=true`; without it the server returns
 - **Auth** (`internal/auth/`) — OIDC login flow (`/api/auth/{login,
   callback,logout,me}`) with PKCE + state + nonce, allowlist gate on
   email / domain / group claims, and HMAC-SHA256-signed cookie sessions
-  (no DB). `MCPMiddleware` checks `Authorization: Bearer …` against the
-  static keys in `auth.mcp_keys` for `/mcp`; stdio MCP stays open. Auth
-  is fully off when `auth.enabled = false` (the default).
+  (no DB). Two roles: `authorize()` resolves each session to `admin`
+  (read + write) or `readonly` (GET only). `admin` ⇔ identity matches the
+  `[auth.access.admin]` allowlist; everyone else who passes the sign-in
+  allowlist is `readonly`. When `[auth.access.admin]` is empty, every
+  signed-in user is `admin` (pre-role default). The middleware enforces
+  it by HTTP method — any `POST/PUT/PATCH/DELETE` under `/api/` needs the
+  `admin` role (403 otherwise), so write gating is automatic for new
+  routes. The role rides in `/api/auth/me` (`"role"`); the SPA hides
+  destructive controls for `readonly`. `MCPMiddleware` checks
+  `Authorization: Bearer …` against the static keys in `auth.mcp_keys`
+  for `/mcp`; stdio MCP stays open. Auth is fully off when
+  `auth.enabled = false` (the default).
 
 ## Tech / versions
 

--- a/chart/cheshmhayash-chart/Chart.yaml
+++ b/chart/cheshmhayash-chart/Chart.yaml
@@ -4,11 +4,11 @@ description: NATS administration dashboard served over the NATS protocol itself.
 type: application
 
 # Chart version — bump on every chart change (independent of appVersion).
-version: 1.2.0
+version: 1.3.0
 
 # Application version — matches the cheshmhayash binary release. The
 # release.yaml workflow rewrites this to the pushed tag's version.
-appVersion: "0.8.0"
+appVersion: "0.10.0"
 
 # Lower bound for the Kubernetes API. autoscaling/v2 is the strictest
 # requirement (GA in 1.23). The chart is tested against the in-support
@@ -42,4 +42,4 @@ annotations:
       url: https://nats.io
   artifacthub.io/changes: |
     - kind: added
-      description: Binary version stamped at build time (via `-ldflags -X internal/version.Version`) and exposed at `GET /api/version` — the SPA footer renders it for at-a-glance deploy verification.
+      description: "Role-based dashboard access: the new `[auth.access.admin]` allowlist (`access.admin.allowed{Emails,Domains,Groups}` in values) splits write (admin) from read-only. Signed-in users not on the admin list get read-only access; the server rejects their mutating requests with 403 and the SPA hides destructive controls. Leave the admin list empty for the legacy all-access behaviour."

--- a/chart/cheshmhayash-chart/templates/_helpers.tpl
+++ b/chart/cheshmhayash-chart/templates/_helpers.tpl
@@ -189,6 +189,19 @@ allowed_groups = [{{ range $i, $s := . }}{{ if $i }}, {{ end }}"{{ $s }}"{{ end 
 {{- if .Values.auth.access.groupsClaim }}
 groups_claim = "{{ .Values.auth.access.groupsClaim }}"
 {{- end }}
+{{- if or .Values.auth.access.admin.allowedEmails .Values.auth.access.admin.allowedDomains .Values.auth.access.admin.allowedGroups }}
+
+[auth.access.admin]
+{{- with .Values.auth.access.admin.allowedEmails }}
+allowed_emails = [{{ range $i, $s := . }}{{ if $i }}, {{ end }}"{{ $s }}"{{ end }}]
+{{- end }}
+{{- with .Values.auth.access.admin.allowedDomains }}
+allowed_domains = [{{ range $i, $s := . }}{{ if $i }}, {{ end }}"{{ $s }}"{{ end }}]
+{{- end }}
+{{- with .Values.auth.access.admin.allowedGroups }}
+allowed_groups = [{{ range $i, $s := . }}{{ if $i }}, {{ end }}"{{ $s }}"{{ end }}]
+{{- end }}
+{{- end }}
 
 [auth.session]
 ttl_seconds = {{ .Values.auth.session.ttlSeconds }}

--- a/chart/cheshmhayash-chart/values.yaml
+++ b/chart/cheshmhayash-chart/values.yaml
@@ -290,11 +290,22 @@ auth:
     #   name: cheshmhayash-oidc
     #   key: client_secret
   access:
-    # At least one of these three must be non-empty when `auth.enabled`.
+    # Sign-in allowlist — at least one of these three must be non-empty
+    # when `auth.enabled`. Everyone who matches may open the dashboard and
+    # read; write access is granted separately by `access.admin` below.
     allowedEmails: []
     allowedDomains: []
     allowedGroups: []
     groupsClaim: groups
+    # Write-access (admin) allowlist. A signed-in user who additionally
+    # matches anything here gets the "admin" role (full read + write);
+    # everyone else who passes the sign-in allowlist above is read-only.
+    # Leave all three empty to grant every signed-in user full access
+    # (the legacy, pre-role behaviour).
+    admin:
+      allowedEmails: []
+      allowedDomains: []
+      allowedGroups: []
   session:
     ttlSeconds: 43200
     cookieName: cheshmhayash_session

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,8 @@ import { LoginScreen } from "./components/LoginScreen";
 import { ToastProvider, useToast } from "./state/toast";
 import { ConfirmProvider } from "./components/ConfirmDialog";
 import { Footer } from "./components/Footer";
-import { useAuth, displayName } from "./hooks/useAuth";
+import { useAuth, displayName, canWrite } from "./hooks/useAuth";
+import { CanWriteProvider } from "./state/access";
 
 type Tab = "servers" | "accounts" | "jetstream" | "topology";
 
@@ -68,8 +69,12 @@ function Shell() {
     return <LoginScreen />;
   }
 
+  const writable = canWrite(status);
+  const readOnly =
+    status.state === "authenticated" && status.identity.role === "readonly";
+
   return (
-    <>
+    <CanWriteProvider value={writable}>
       <section className="hero" aria-label="cheshmhayash">
         <div className="hero-overlay">
           <h1 className="hero-title">cheshmhayash</h1>
@@ -130,6 +135,11 @@ function Shell() {
           </button>
           {status.state === "authenticated" ? (
             <div className="user-menu">
+              {readOnly ? (
+                <span className="role-badge" title="You have read-only access; write actions are hidden.">
+                  read-only
+                </span>
+              ) : null}
               <span
                 className="who"
                 title={status.identity.email ?? status.identity.sub ?? ""}
@@ -168,6 +178,6 @@ function Shell() {
         )}
       </main>
       <Footer />
-    </>
+    </CanWriteProvider>
   );
 }

--- a/frontend/src/components/ServerDetail.tsx
+++ b/frontend/src/components/ServerDetail.tsx
@@ -5,6 +5,7 @@ import { bytes, iso, num } from "../fmt";
 import type { PingReply, VarzReply, ConnzReply, HealthzReply } from "../types";
 import { useConfirm } from "./ConfirmDialog";
 import { useToast } from "../state/toast";
+import { useCanWrite } from "../state/access";
 
 const SUBTABS = [
   "overview",
@@ -28,6 +29,7 @@ interface Props {
 
 export function ServerDetail({ cluster, server, onClose }: Props) {
   const [tab, setTab] = useState<Subtab>("overview");
+  const canWrite = useCanWrite();
   const id = server.server.id;
 
   return (
@@ -38,7 +40,7 @@ export function ServerDetail({ cluster, server, onClose }: Props) {
           <div className="sub">{id}</div>
         </div>
         <div className="spacer"></div>
-        <ServerActions cluster={cluster} server={server} />
+        {canWrite ? <ServerActions cluster={cluster} server={server} /> : null}
         <button className="close-btn" onClick={onClose} aria-label="close">
           <X size={18} />
         </button>

--- a/frontend/src/components/StreamDetail.tsx
+++ b/frontend/src/components/StreamDetail.tsx
@@ -5,6 +5,7 @@ import { bytes, duration, iso, num } from "../fmt";
 import type { AggregatedOverview, AggregatedStream } from "../types";
 import { useConfirm } from "./ConfirmDialog";
 import { useToast } from "../state/toast";
+import { useCanWrite } from "../state/access";
 import { StreamEditor } from "./StreamEditor";
 
 interface Props {
@@ -28,6 +29,7 @@ export function StreamDetail({
   const s: AggregatedStream | undefined = acct?.streams.find((x) => x.name === streamName);
   const confirm = useConfirm();
   const toast = useToast();
+  const canWrite = useCanWrite();
   const [editing, setEditing] = useState(false);
 
   if (!s) return null;
@@ -97,24 +99,26 @@ export function StreamDetail({
             </div>
           </div>
           <div className="spacer"></div>
-          <div className="detail-actions">
-            <button onClick={() => setEditing(true)}>
-              <Pencil size={14} />
-              Edit
-            </button>
-            <button onClick={stepdown} title="Force raft leader re-election">
-              <Crown size={14} />
-              Step down
-            </button>
-            <button className="danger" onClick={purge}>
-              <Eraser size={14} />
-              Purge
-            </button>
-            <button className="danger" onClick={del}>
-              <Trash2 size={14} />
-              Delete
-            </button>
-          </div>
+          {canWrite ? (
+            <div className="detail-actions">
+              <button onClick={() => setEditing(true)}>
+                <Pencil size={14} />
+                Edit
+              </button>
+              <button onClick={stepdown} title="Force raft leader re-election">
+                <Crown size={14} />
+                Step down
+              </button>
+              <button className="danger" onClick={purge}>
+                <Eraser size={14} />
+                Purge
+              </button>
+              <button className="danger" onClick={del}>
+                <Trash2 size={14} />
+                Delete
+              </button>
+            </div>
+          ) : null}
           <button className="close-btn" onClick={onClose} aria-label="close">
             <X size={18} />
           </button>
@@ -183,13 +187,15 @@ export function StreamDetail({
                         <td className="num">{num(c.num_pending)}</td>
                         <td className="mono">{c.cluster?.leader ?? ""}</td>
                         <td>
-                          <button
-                            className="link-btn"
-                            title="Force consumer raft re-election"
-                            onClick={() => consumerStepdown(name, c.cluster?.leader)}
-                          >
-                            step down
-                          </button>
+                          {canWrite ? (
+                            <button
+                              className="link-btn"
+                              title="Force consumer raft re-election"
+                              onClick={() => consumerStepdown(name, c.cluster?.leader)}
+                            >
+                              step down
+                            </button>
+                          ) : null}
                         </td>
                       </tr>
                     );

--- a/frontend/src/components/TopologyView.tsx
+++ b/frontend/src/components/TopologyView.tsx
@@ -6,6 +6,7 @@ import { num } from "../fmt";
 import { TopologyGraph, type GraphRaftGroup } from "./TopologyGraph";
 import { useConfirm } from "./ConfirmDialog";
 import { useToast } from "../state/toast";
+import { useCanWrite } from "../state/access";
 import { useOverviewStream } from "../hooks/useOverviewStream";
 import { StreamStatus } from "./StreamStatus";
 
@@ -478,6 +479,7 @@ function MetaStepdownButton({
 }) {
   const confirm = useConfirm();
   const toast = useToast();
+  const canWrite = useCanWrite();
   async function go() {
     if (!(await confirm.ask(
       "Step down meta leader",
@@ -491,6 +493,7 @@ function MetaStepdownButton({
       toast.push(`step-down failed: ${(e as Error).message}`, "error");
     }
   }
+  if (!canWrite) return null;
   return (
     <button
       className="link-btn"

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
+export type Role = "admin" | "readonly";
+
 export interface AuthIdentity {
   authenticated: boolean;
   sub?: string;
@@ -8,6 +10,19 @@ export interface AuthIdentity {
   given_name?: string;
   family_name?: string;
   groups?: string[];
+  role?: Role;
+}
+
+// canWrite decides whether mutating controls should be shown. Auth-disabled
+// deployments ("disabled" status) keep full access, matching the
+// backward-compatible server default. When authenticated, only the admin
+// role may write; a missing role (older server) is treated as admin so a
+// dashboard never silently loses its controls after a partial upgrade.
+export function canWrite(status: AuthStatus): boolean {
+  if (status.state === "authenticated") {
+    return status.identity.role !== "readonly";
+  }
+  return status.state === "disabled";
 }
 
 // displayName picks the best label to show in the UI:

--- a/frontend/src/state/access.ts
+++ b/frontend/src/state/access.ts
@@ -1,0 +1,14 @@
+import { createContext, useContext } from "react";
+
+// CanWriteContext carries whether the current session may issue mutating
+// requests. Defaults to true so any component rendered outside a provider
+// (and every auth-disabled deployment) behaves exactly as before roles
+// existed. The Shell lowers it to false for read-only sessions, which hides
+// the destructive controls (the server enforces the same gate regardless).
+const CanWriteContext = createContext<boolean>(true);
+
+export const CanWriteProvider = CanWriteContext.Provider;
+
+export function useCanWrite(): boolean {
+  return useContext(CanWriteContext);
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1089,3 +1089,15 @@ dialog button.primary:hover {
 .user-menu .icon-btn {
   padding: 4px 6px;
 }
+.role-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: rgba(243, 183, 96, 0.15);
+  color: var(--warn);
+  border: 1px solid rgba(243, 183, 96, 0.35);
+  border-radius: 4px;
+  padding: 1px 6px;
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -72,22 +72,31 @@ func (a *Authenticator) Enabled() bool {
 	return a != nil && a.cfg.Enabled
 }
 
-// allowed checks the post-login allowlist. Empty slices are ignored
-// (Settings.validate already requires at least one of the three).
-func (a *Authenticator) allowed(s sessionData) bool {
-	for _, e := range a.cfg.Access.AllowedEmails {
+// Role is the access tier a session resolves to. RoleReadOnly may issue
+// only safe (GET) requests; RoleAdmin may also mutate (POST/PUT/DELETE).
+type Role string
+
+const (
+	RoleReadOnly Role = "readonly"
+	RoleAdmin    Role = "admin"
+)
+
+// matchIdentity reports whether the session satisfies any of the given
+// email / domain / group rules. Empty slices match nobody.
+func matchIdentity(s sessionData, emails, domains, groups []string) bool {
+	for _, e := range emails {
 		if strings.EqualFold(e, s.Email) {
 			return true
 		}
 	}
 	if domain := domainOf(s.Email); domain != "" {
-		for _, d := range a.cfg.Access.AllowedDomains {
+		for _, d := range domains {
 			if strings.EqualFold(d, domain) {
 				return true
 			}
 		}
 	}
-	for _, want := range a.cfg.Access.AllowedGroups {
+	for _, want := range groups {
 		for _, have := range s.Groups {
 			if strings.EqualFold(want, have) {
 				return true
@@ -95,6 +104,41 @@ func (a *Authenticator) allowed(s sessionData) bool {
 		}
 	}
 	return false
+}
+
+// authorize decides whether a session may access the dashboard and at what
+// role. A user is let in if they match the sign-in allowlist OR the admin
+// allowlist (so an admin who isn't also on the base list still gets in).
+//
+// Role resolution:
+//   - admin allowlist empty  → every signed-in user is RoleAdmin (this is
+//     the pre-role behaviour, kept for backward compatibility).
+//   - matches admin allowlist → RoleAdmin.
+//   - otherwise (sign-in only) → RoleReadOnly.
+//
+// Re-evaluated on every request, so moving someone between tiers in
+// settings takes effect on their next call without a re-login.
+func (a *Authenticator) authorize(s sessionData) (Role, bool) {
+	base := matchIdentity(s, a.cfg.Access.AllowedEmails, a.cfg.Access.AllowedDomains, a.cfg.Access.AllowedGroups)
+	admin := matchIdentity(s,
+		a.cfg.Access.Admin.AllowedEmails,
+		a.cfg.Access.Admin.AllowedDomains,
+		a.cfg.Access.Admin.AllowedGroups,
+	)
+
+	if a.cfg.Access.Admin.IsEmpty() {
+		if base {
+			return RoleAdmin, true
+		}
+		return "", false
+	}
+	if admin {
+		return RoleAdmin, true
+	}
+	if base {
+		return RoleReadOnly, true
+	}
+	return "", false
 }
 
 func domainOf(email string) string {
@@ -114,7 +158,7 @@ const (
 
 // Identity is the subset of session data we expose to other packages —
 // kept tiny on purpose so handlers don't grow accidental dependencies on
-// the cookie format.
+// the cookie format. Role is the resolved access tier.
 type Identity struct {
 	Sub        string
 	Email      string
@@ -122,15 +166,24 @@ type Identity struct {
 	GivenName  string
 	FamilyName string
 	Groups     []string
+	Role       Role
+}
+
+// sessionCtx is what the middleware stashes in the request context: the
+// verified cookie payload plus the role resolved for this request.
+type sessionCtx struct {
+	data sessionData
+	role Role
 }
 
 // FromContext returns the identity attached by the middleware, or zero if
 // none — useful for /api/auth/me.
 func FromContext(ctx context.Context) (Identity, bool) {
-	s, ok := ctx.Value(sessionKey).(sessionData)
+	v, ok := ctx.Value(sessionKey).(sessionCtx)
 	if !ok {
 		return Identity{}, false
 	}
+	s := v.data
 	return Identity{
 		Sub:        s.Sub,
 		Email:      s.Email,
@@ -138,11 +191,12 @@ func FromContext(ctx context.Context) (Identity, bool) {
 		GivenName:  s.GivenName,
 		FamilyName: s.FamilyName,
 		Groups:     s.Groups,
+		Role:       v.role,
 	}, true
 }
 
 // withSession returns a new request whose context carries the verified
-// session payload.
-func withSession(r *http.Request, s sessionData) *http.Request {
-	return r.WithContext(context.WithValue(r.Context(), sessionKey, s))
+// session payload and resolved role.
+func withSession(r *http.Request, s sessionData, role Role) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), sessionKey, sessionCtx{data: s, role: role}))
 }

--- a/internal/auth/authorize_test.go
+++ b/internal/auth/authorize_test.go
@@ -1,0 +1,91 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/1995parham/cheshmhayash/internal/config"
+)
+
+// auth builds an Authenticator with just the Access config populated —
+// enough to exercise authorize without an OIDC provider.
+func authFor(access config.AuthAccess) *Authenticator {
+	return &Authenticator{cfg: config.Auth{Access: access}}
+}
+
+func TestAuthorize_NoAdminAllowlist_GrantsAdmin(t *testing.T) {
+	// Backward-compatible: with no admin allowlist, every signed-in user is
+	// an admin (full access, same as before roles existed).
+	a := authFor(config.AuthAccess{AllowedDomains: []string{"snappcloud.io"}})
+
+	role, ok := a.authorize(sessionData{Email: "ops@snappcloud.io"})
+	if !ok || role != RoleAdmin {
+		t.Fatalf("want admin/true, got %q/%v", role, ok)
+	}
+
+	if _, ok := a.authorize(sessionData{Email: "intruder@example.com"}); ok {
+		t.Fatal("non-allowlisted email must be denied")
+	}
+}
+
+func TestAuthorize_AdminAllowlist_SplitsTiers(t *testing.T) {
+	a := authFor(config.AuthAccess{
+		AllowedDomains: []string{"snapp.cab"},
+		Admin:          config.AccessRule{AllowedDomains: []string{"snappcloud.io"}},
+	})
+
+	cases := []struct {
+		email    string
+		groups   []string
+		wantRole Role
+		wantOK   bool
+	}{
+		{email: "platform@snappcloud.io", wantRole: RoleAdmin, wantOK: true},
+		{email: "employee@snapp.cab", wantRole: RoleReadOnly, wantOK: true},
+		{email: "stranger@gmail.com", wantOK: false},
+	}
+	for _, c := range cases {
+		role, ok := a.authorize(sessionData{Email: c.email, Groups: c.groups})
+		if ok != c.wantOK || (ok && role != c.wantRole) {
+			t.Errorf("authorize(%s) = %q/%v, want %q/%v", c.email, role, ok, c.wantRole, c.wantOK)
+		}
+	}
+}
+
+func TestAuthorize_AdminNotOnBaseList_StillAdmin(t *testing.T) {
+	// An admin matched only by the admin allowlist (not the sign-in list)
+	// must still be let in — authorize ORs the two.
+	a := authFor(config.AuthAccess{
+		AllowedDomains: []string{"snapp.cab"},
+		Admin:          config.AccessRule{AllowedEmails: []string{"contractor@external.com"}},
+	})
+	role, ok := a.authorize(sessionData{Email: "contractor@external.com"})
+	if !ok || role != RoleAdmin {
+		t.Fatalf("want admin/true, got %q/%v", role, ok)
+	}
+}
+
+func TestAuthorize_AdminByGroup(t *testing.T) {
+	a := authFor(config.AuthAccess{
+		AllowedDomains: []string{"snapp.cab"},
+		Admin:          config.AccessRule{AllowedGroups: []string{"nats-admins"}},
+	})
+	role, ok := a.authorize(sessionData{Email: "lead@snapp.cab", Groups: []string{"nats-admins", "eng"}})
+	if !ok || role != RoleAdmin {
+		t.Fatalf("group admin: want admin/true, got %q/%v", role, ok)
+	}
+	role, ok = a.authorize(sessionData{Email: "lead@snapp.cab", Groups: []string{"eng"}})
+	if !ok || role != RoleReadOnly {
+		t.Fatalf("non-admin group: want readonly/true, got %q/%v", role, ok)
+	}
+}
+
+func TestIsWriteMethod(t *testing.T) {
+	for m, want := range map[string]bool{
+		"GET": false, "HEAD": false, "OPTIONS": false,
+		"POST": true, "PUT": true, "PATCH": true, "DELETE": true,
+	} {
+		if got := isWriteMethod(m); got != want {
+			t.Errorf("isWriteMethod(%s) = %v, want %v", m, got, want)
+		}
+	}
+}

--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -119,7 +119,8 @@ func (a *Authenticator) handleCallback(w http.ResponseWriter, r *http.Request) {
 		a.callbackError(w, r, err.Error())
 		return
 	}
-	if !a.allowed(sess) {
+	role, ok := a.authorize(sess)
+	if !ok {
 		a.log.Warn("auth: rejected — not on allowlist", "email", sess.Email, "sub", sess.Sub)
 		http.Error(w, "access denied: "+sess.Email+" is not on the allowlist", http.StatusForbidden)
 		return
@@ -128,7 +129,7 @@ func (a *Authenticator) handleCallback(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "write session: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	a.log.Info("auth: login", "email", sess.Email, "sub", sess.Sub)
+	a.log.Info("auth: login", "email", sess.Email, "sub", sess.Sub, "role", role)
 	http.Redirect(w, r, flow.ReturnTo, http.StatusFound)
 }
 
@@ -137,40 +138,39 @@ func (a *Authenticator) handleLogout(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 
-// handleMe returns 200 + identity when authenticated, 401 otherwise. The
-// SPA polls this on boot to decide whether to show the login splash.
+// handleMe returns 200 + identity (incl. role) when authenticated, 401
+// otherwise. The SPA polls this on boot to decide whether to show the
+// login splash and which write controls to render. Middleware lets
+// /api/auth/* through without injecting context, so we resolve from the
+// cookie directly here.
 func (a *Authenticator) handleMe(w http.ResponseWriter, r *http.Request) {
-	id, ok := FromContext(r.Context())
+	c, err := r.Cookie(a.cfg.Session.CookieName)
+	if err != nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]any{"authenticated": false})
+		return
+	}
+	s, err := a.signer.readSession(c.Value)
+	if err != nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]any{"authenticated": false})
+		return
+	}
+	role, ok := a.authorize(s)
 	if !ok {
-		// Try to read directly — middleware lets /api/auth/* through
-		// without injecting context, so we resolve here.
-		c, err := r.Cookie(a.cfg.Session.CookieName)
-		if err != nil {
-			writeJSON(w, http.StatusUnauthorized, map[string]any{"authenticated": false})
-			return
-		}
-		s, err := a.signer.readSession(c.Value)
-		if err != nil {
-			writeJSON(w, http.StatusUnauthorized, map[string]any{"authenticated": false})
-			return
-		}
-		id = Identity{
-			Sub:        s.Sub,
-			Email:      s.Email,
-			Name:       s.Name,
-			GivenName:  s.GivenName,
-			FamilyName: s.FamilyName,
-			Groups:     s.Groups,
-		}
+		writeJSON(w, http.StatusForbidden, map[string]any{
+			"authenticated": false,
+			"message":       "access denied",
+		})
+		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"authenticated": true,
-		"sub":           id.Sub,
-		"email":         id.Email,
-		"name":          id.Name,
-		"given_name":    id.GivenName,
-		"family_name":   id.FamilyName,
-		"groups":        id.Groups,
+		"sub":           s.Sub,
+		"email":         s.Email,
+		"name":          s.Name,
+		"given_name":    s.GivenName,
+		"family_name":   s.FamilyName,
+		"groups":        s.Groups,
+		"role":          string(role),
 	})
 }
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -36,18 +36,42 @@ func (a *Authenticator) Middleware(next http.Handler) http.Handler {
 			return
 		}
 		// Cookie outlived the allowlist — re-checks every request so
-		// kicking someone is as simple as removing them from settings.toml
-		// and either reloading the binary or letting the next-request
-		// path tear their session down.
-		if !a.allowed(sess) {
+		// kicking someone (or changing their tier) is as simple as editing
+		// settings.toml; the next request re-resolves it.
+		role, ok := a.authorize(sess)
+		if !ok {
 			clearCookie(w, a.cfg.Session.CookieName, a.cfg.Session.Secure)
 			writeJSON(w, http.StatusForbidden, map[string]any{
 				"message": "access denied",
 			})
 			return
 		}
-		next.ServeHTTP(w, withSession(r, sess))
+		// Read-only sessions may issue safe requests only. Every mutating
+		// API route is POST/PUT/PATCH/DELETE, so gating by method is
+		// sufficient — and resilient to new write routes being added.
+		// Public paths (/api/auth/*, /mcp, healthz, version, SPA) already
+		// returned above via isPublic, so this only fences /api/admin and
+		// /api/jsm mutations.
+		if role != RoleAdmin && isWriteMethod(r.Method) {
+			writeJSON(w, http.StatusForbidden, map[string]any{
+				"message": "write access requires the admin role",
+				"role":    string(role),
+			})
+			return
+		}
+		next.ServeHTTP(w, withSession(r, sess, role))
 	})
+}
+
+// isWriteMethod reports whether an HTTP method mutates state. OPTIONS is
+// short-circuited by the CORS middleware before it reaches here.
+func isWriteMethod(m string) bool {
+	switch m {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
 }
 
 // isPublic lists the path prefixes that bypass the session check. SPA

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,14 +58,37 @@ type AuthOIDC struct {
 	Scopes       []string `json:"scopes"       koanf:"scopes"`
 }
 
-// AuthAccess is the post-login allowlist. At least one of the three slices
-// must be populated when auth is enabled — otherwise any account in the
-// IdP can sign in, which is almost never what you want.
+// AuthAccess is the post-login allowlist. At least one of the three
+// sign-in slices must be populated when auth is enabled — otherwise any
+// account in the IdP can sign in, which is almost never what you want.
+//
+// The sign-in slices (AllowedEmails/Domains/Groups) decide who may open
+// the dashboard at all; everyone who passes them gets at least read-only
+// access. Admin carries a second, write-access allowlist: a signed-in
+// user who additionally matches it gets the "admin" role (full read +
+// write). When Admin is empty every signed-in user is an admin, which
+// preserves the pre-role behaviour where any allowed account had full
+// access.
 type AuthAccess struct {
+	AllowedEmails  []string   `json:"allowed_emails,omitempty"  koanf:"allowed_emails"`
+	AllowedDomains []string   `json:"allowed_domains,omitempty" koanf:"allowed_domains"`
+	AllowedGroups  []string   `json:"allowed_groups,omitempty"  koanf:"allowed_groups"`
+	GroupsClaim    string     `json:"groups_claim,omitempty"    koanf:"groups_claim"`
+	Admin          AccessRule `json:"admin,omitzero"            koanf:"admin"`
+}
+
+// AccessRule is an email/domain/group allowlist triple. Used for the
+// write-access (admin) tier; the same matching logic as the sign-in
+// allowlist, scoped to a narrower set of identities.
+type AccessRule struct {
 	AllowedEmails  []string `json:"allowed_emails,omitempty"  koanf:"allowed_emails"`
 	AllowedDomains []string `json:"allowed_domains,omitempty" koanf:"allowed_domains"`
 	AllowedGroups  []string `json:"allowed_groups,omitempty"  koanf:"allowed_groups"`
-	GroupsClaim    string   `json:"groups_claim,omitempty"    koanf:"groups_claim"`
+}
+
+// IsEmpty reports whether the rule matches nobody (all three slices empty).
+func (r AccessRule) IsEmpty() bool {
+	return len(r.AllowedEmails) == 0 && len(r.AllowedDomains) == 0 && len(r.AllowedGroups) == 0
 }
 
 type AuthSession struct {
@@ -297,6 +320,7 @@ func applyEnvPath(s *Settings, parts []string, val string) error {
 //	enabled
 //	oidc.{issuer,client_id,client_secret,redirect_url,scopes}     scopes is comma-separated
 //	access.{allowed_emails,allowed_domains,allowed_groups,groups_claim}   slices comma-separated
+//	access.admin.{allowed_emails,allowed_domains,allowed_groups}          write-access allowlist
 //	session.{secret,ttl_seconds,cookie_name,secure}
 //	mcp_keys.<idx>.{name,value}
 func applyAuthEnv(a *Auth, parts []string, val string) error {
@@ -329,21 +353,7 @@ func applyAuthEnv(a *Auth, parts []string, val string) error {
 			return fmt.Errorf("unknown auth.oidc field %q", parts[1])
 		}
 	case "access":
-		if len(parts) != 2 {
-			return fmt.Errorf("expected auth.access.<key>")
-		}
-		switch strings.ToLower(parts[1]) {
-		case "allowed_emails":
-			a.Access.AllowedEmails = splitCSV(val)
-		case "allowed_domains":
-			a.Access.AllowedDomains = splitCSV(val)
-		case "allowed_groups":
-			a.Access.AllowedGroups = splitCSV(val)
-		case "groups_claim":
-			a.Access.GroupsClaim = val
-		default:
-			return fmt.Errorf("unknown auth.access field %q", parts[1])
-		}
+		return applyAccessEnv(&a.Access, parts[1:], val)
 	case "session":
 		if len(parts) != 2 {
 			return fmt.Errorf("expected auth.session.<key>")
@@ -389,6 +399,42 @@ func applyAuthEnv(a *Auth, parts []string, val string) error {
 		}
 	default:
 		return fmt.Errorf("unknown auth field %q", parts[0])
+	}
+	return nil
+}
+
+// applyAccessEnv handles CHESHMHAYASH__AUTH__ACCESS__* env keys, including
+// the nested admin allowlist (auth.access.admin.allowed_{emails,domains,
+// groups}). Slice values are comma-separated.
+func applyAccessEnv(acc *AuthAccess, parts []string, val string) error {
+	if len(parts) == 0 {
+		return fmt.Errorf("expected auth.access.<key>")
+	}
+	switch strings.ToLower(parts[0]) {
+	case "allowed_emails":
+		acc.AllowedEmails = splitCSV(val)
+	case "allowed_domains":
+		acc.AllowedDomains = splitCSV(val)
+	case "allowed_groups":
+		acc.AllowedGroups = splitCSV(val)
+	case "groups_claim":
+		acc.GroupsClaim = val
+	case "admin":
+		if len(parts) != 2 {
+			return fmt.Errorf("expected auth.access.admin.<key>")
+		}
+		switch strings.ToLower(parts[1]) {
+		case "allowed_emails":
+			acc.Admin.AllowedEmails = splitCSV(val)
+		case "allowed_domains":
+			acc.Admin.AllowedDomains = splitCSV(val)
+		case "allowed_groups":
+			acc.Admin.AllowedGroups = splitCSV(val)
+		default:
+			return fmt.Errorf("unknown auth.access.admin field %q", parts[1])
+		}
+	default:
+		return fmt.Errorf("unknown auth.access field %q", parts[0])
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -146,11 +146,18 @@ func run(log *slog.Logger) error {
 		if err != nil {
 			return fmt.Errorf("auth init: %w", err)
 		}
+		admin := settings.Auth.Access.Admin
 		log.Info("auth enabled",
 			"issuer", settings.Auth.OIDC.Issuer,
 			"allowed_emails", len(settings.Auth.Access.AllowedEmails),
 			"allowed_domains", len(settings.Auth.Access.AllowedDomains),
 			"allowed_groups", len(settings.Auth.Access.AllowedGroups),
+			"admin_emails", len(admin.AllowedEmails),
+			"admin_domains", len(admin.AllowedDomains),
+			"admin_groups", len(admin.AllowedGroups),
+			// When the admin allowlist is empty every signed-in user is an
+			// admin (legacy behaviour); log it so the tier model is obvious.
+			"admin_allowlist_set", !admin.IsEmpty(),
 		)
 	}
 	mcpKeys := mcpKeyMatchers(settings.Auth.MCPKeys)


### PR DESCRIPTION
## Summary

Adds a **read-only vs admin** access split to the OIDC-gated dashboard. Until now any allowed account had full access; this introduces a second allowlist for write privileges.

- **admin** — full read + write (purge / delete / kick / reload / stepdown / stream edit)
- **readonly** — GET only; mutating requests get `403`, and the SPA hides the destructive controls

A signed-in user is **admin** when their identity matches the new `[auth.access.admin]` allowlist (emails / domains / groups — same matcher as the sign-in list). Everyone else who passes the sign-in allowlist is **readonly**. When `[auth.access.admin]` is empty, **every** signed-in user is admin — so existing deployments behave exactly as before.

## Backend
- `config`: `AuthAccess.Admin` (`AccessRule`) + `CHESHMHAYASH__AUTH__ACCESS__ADMIN__*` env overlay.
- `auth.authorize()` resolves `(Role, ok)` and replaces `allowed()`. The middleware enforces it **by HTTP method** — any `POST/PUT/PATCH/DELETE` under `/api/` requires admin (so new write routes are gated automatically). Role is surfaced in `/api/auth/me`.
- New unit tests for tier resolution + the method gate.

## Frontend
- `/api/auth/me` `role` drives a `canWrite` React context. `ServerDetail`, `StreamDetail`, `TopologyView` hide destructive controls for read-only sessions; a `read-only` badge shows in the header.

## Chart
- `auth.access.admin.allowed{Emails,Domains,Groups}` values render an `[auth.access.admin]` block. Chart `1.2.0 → 1.3.0`, appVersion `→ 0.10.0`.

## Verify
`gofmt`/`go vet`/`go test`/`tsc -b`/`vite build`/`helm lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)