### PR TITLE
chore: golangci-lint as the single Go lint/format gate (~all linters)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,22 +25,13 @@ jobs:
           go-version: "1.26.3"
           check-latest: true
 
-      - name: go vet
-        run: go vet ./...
-
-      - name: go fmt
-        run: |
-          out=$(gofmt -l .)
-          if [ -n "$out" ]; then
-            echo "::error::gofmt found unformatted files:"
-            echo "$out"
-            exit 1
-          fi
-
+      # golangci-lint is the single source of truth for Go linting: `run`
+      # also reports the `formatters` (gofmt/goimports) as issues and runs
+      # go vet (govet), so there are no separate vet/fmt steps.
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.12.2
+          version: latest
           args: --timeout=5m
 
   backend-test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,81 @@
+# golangci-lint is the single source of truth for Go linting + formatting.
+# It runs `go vet` (govet), gofmt/goimports, and a broad linter set, so the
+# CI workflow no longer runs `go vet` / `gofmt` separately.
+#
+# Policy: enable everything (`default: all`), then disable only the linters
+# that fight this codebase's deliberate conventions or are pure style dogma.
+# Each disable carries a one-line reason so the list stays honest over time.
+version: "2"
+
+linters:
+  default: all
+  disable:
+    # --- whitespace / layout dogma ---------------------------------------
+    - wsl          # enforces blank-line placement; cosmetic, high-churn
+    - wsl_v5       # newer wsl, same objection
+    - nlreturn     # demands a blank line before every return
+    # --- naming / short-identifier dogma ---------------------------------
+    - varnamelen   # flags idiomatic short names (i, r, w, c, ok)
+    - tagliatelle  # would fight our snake_case koanf struct tags
+    # --- error-handling dogma --------------------------------------------
+    - err113       # bans dynamic errors.New/fmt.Errorf at call sites
+    - wrapcheck    # demands every external error be wrapped
+    - noinlineerr  # bans the idiomatic `if err := f(); err != nil` form
+    # --- struct / interface dogma ----------------------------------------
+    - exhaustruct  # requires every struct field to be set explicitly
+    - ireturn      # bans returning interfaces
+    - nonamedreturns
+    - nilnil       # `return nil, nil` is intentional (e.g. extractGroups)
+    # --- dependency / global policy --------------------------------------
+    - depguard         # needs a bespoke import allowlist we don't want
+    - gomodguard       # ditto for modules (deprecated alias) — no policy
+    - gomodguard_v2    # ditto — no module blocklist policy
+    - gochecknoglobals # version.Version, natsx.Logger are intentional
+    # --- complexity (large config switch statements are deliberate) ------
+    - cyclop
+    - funlen
+    - gocognit
+    - gocyclo
+    - nestif
+    - maintidx
+    # --- magic numbers / misc noise --------------------------------------
+    - mnd          # flags timeouts/sizes that are clearer inline
+    - lll          # line-length; we wrap by judgement, not a hard column
+    - godox        # allow TODO/FIXME markers
+    - dupl         # false positives across the parallel HTTP handlers
+    - forcetypeassert # a few asserts are guarded by intent, not by ok
+    # --- test-style dogma ------------------------------------------------
+    - paralleltest # not every test benefits from t.Parallel
+    - testpackage  # tests need package-internal access (sessionData, …)
+    # --- ordering / repetition (high churn, low signal here) -------------
+    - funcorder    # would reorder methods away from their call-flow order
+    - goconst      # flags JSON-RPC field names + test fixtures, not real dups
+    - prealloc     # flags an intentional literal + conditional-append slice
+
+  settings:
+    gosec:
+      excludes:
+        # Secure on cookies is operator-configurable (false for local HTTP
+        # dev, true behind TLS) — flagged at the SetCookie call sites.
+        - G124
+        # API responses stream raw JSON straight from NATS with a JSON
+        # content-type; the XSS taint heuristic is a false positive here.
+        - G705
+    exhaustive:
+      # A switch with a default that returns an error is exhaustive enough;
+      # don't demand every reflect.Kind be enumerated.
+      default-signifies-exhaustive: true
+
+  exclusions:
+    # frontend/node_modules ships a vendored Go helper (flatted) that isn't
+    # ours and isn't in the build — never lint it.
+    paths:
+      - frontend/node_modules
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    paths:
+      - frontend/node_modules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,9 +203,12 @@ Destructive verbs require `?confirm=true`; without it the server returns
 ## Conventions
 
 - **Lint on every change** before staging:
-  `gofmt -l`, `go vet ./...`, `golangci-lint run`, `go test ./...`,
-  `npx tsc -b`, `npx vite build`. Zero warnings, zero issues — the CI
-  workflow runs the same set.
+  `golangci-lint run` (the single source of truth for Go — it also
+  reports gofmt/goimports formatting and runs `go vet`; config in
+  `.golangci.yml` enables ~all linters minus documented dogma), `go test
+  ./...`, `npx tsc -b`, `npx vite build`. Zero warnings, zero issues —
+  the CI workflow runs the same set. Use `golangci-lint fmt` to auto-fix
+  formatting.
 - Backend handlers pass NATS replies through as `json.RawMessage` —
   don't unmarshal + re-marshal, it loses field ordering and number
   precision.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -76,6 +76,7 @@ func (a *Authenticator) Enabled() bool {
 // only safe (GET) requests; RoleAdmin may also mutate (POST/PUT/DELETE).
 type Role string
 
+// The two access tiers a session can resolve to.
 const (
 	RoleReadOnly Role = "readonly"
 	RoleAdmin    Role = "admin"

--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -289,5 +290,7 @@ func sanitizeReturnTo(s string) string {
 func writeJSON(w http.ResponseWriter, status int, body any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(body)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		slog.Default().Error("auth: encode response", "err", err)
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,8 @@ const (
 	configFile              = "settings.toml"
 )
 
+// Settings is the fully-resolved runtime configuration (defaults → TOML →
+// env), returned by Load and consumed by main.
 type Settings struct {
 	Server Server   `json:"server"           koanf:"server"`
 	NATS   []NATS   `json:"nats"             koanf:"nats"`
@@ -50,6 +52,7 @@ type Auth struct {
 	MCPKeys []MCPKey    `json:"mcp_keys,omitempty" koanf:"mcp_keys"`
 }
 
+// AuthOIDC holds the OpenID Connect provider coordinates for the login flow.
 type AuthOIDC struct {
 	Issuer       string   `json:"issuer"       koanf:"issuer"`
 	ClientID     string   `json:"client_id"    koanf:"client_id"`
@@ -91,6 +94,7 @@ func (r AccessRule) IsEmpty() bool {
 	return len(r.AllowedEmails) == 0 && len(r.AllowedDomains) == 0 && len(r.AllowedGroups) == 0
 }
 
+// AuthSession configures the HMAC-signed cookie that carries the session.
 type AuthSession struct {
 	Secret     string `json:"-"           koanf:"secret"`
 	TTLSeconds int    `json:"ttl_seconds" koanf:"ttl_seconds"`
@@ -114,11 +118,13 @@ type Notify struct {
 	Username string `json:"username,omitempty" koanf:"username"`
 }
 
+// Server is the HTTP listener's bind address.
 type Server struct {
 	Host string `json:"host" koanf:"host"`
 	Port int    `json:"port" koanf:"port"`
 }
 
+// NATS describes one configured cluster connection.
 type NATS struct {
 	Name      string `json:"name"                 koanf:"name"`
 	URL       string `json:"url"                  koanf:"url"`
@@ -126,11 +132,12 @@ type NATS struct {
 	User      string `json:"user,omitempty"       koanf:"user"`
 	// Password is redacted on the startup log; the JSON tag matters only
 	// for that single pretty-print.
-	Password           string `json:"-"                                  koanf:"password"`
-	RequestTimeoutMS   int    `json:"request_timeout_ms,omitempty"       koanf:"request_timeout_ms"`
-	DiscoveryTimeoutMS int    `json:"discovery_timeout_ms,omitempty"     koanf:"discovery_timeout_ms"`
+	Password           string `json:"-"                              koanf:"password"`
+	RequestTimeoutMS   int    `json:"request_timeout_ms,omitempty"   koanf:"request_timeout_ms"`
+	DiscoveryTimeoutMS int    `json:"discovery_timeout_ms,omitempty" koanf:"discovery_timeout_ms"`
 }
 
+// RequestTimeout is the per-request NATS deadline, defaulted when unset.
 func (n NATS) RequestTimeout() time.Duration {
 	if n.RequestTimeoutMS <= 0 {
 		return defaultRequestTimeout
@@ -138,6 +145,8 @@ func (n NATS) RequestTimeout() time.Duration {
 	return time.Duration(n.RequestTimeoutMS) * time.Millisecond
 }
 
+// DiscoveryTimeout is the deadline for multi-responder discovery requests
+// (e.g. SERVER.PING), defaulted when unset.
 func (n NATS) DiscoveryTimeout() time.Duration {
 	if n.DiscoveryTimeoutMS <= 0 {
 		return defaultDiscoveryTimeout
@@ -145,6 +154,7 @@ func (n NATS) DiscoveryTimeout() time.Duration {
 	return time.Duration(n.DiscoveryTimeoutMS) * time.Millisecond
 }
 
+// Addr is the host:port the HTTP server binds to.
 func (s Server) Addr() string { return fmt.Sprintf("%s:%d", s.Host, s.Port) }
 
 // TTL is the cookie lifetime as a duration. Falls back to 12 h when unset.
@@ -271,7 +281,7 @@ func applyEnvPath(s *Settings, parts []string, val string) error {
 	switch strings.ToLower(parts[0]) {
 	case "server":
 		if len(parts) != 2 {
-			return fmt.Errorf("expected server.<key>")
+			return errors.New("expected server.<key>")
 		}
 		switch strings.ToLower(parts[1]) {
 		case "host":
@@ -287,11 +297,11 @@ func applyEnvPath(s *Settings, parts []string, val string) error {
 		}
 	case "nats":
 		if len(parts) < 3 {
-			return fmt.Errorf("expected nats.<index>.<key>")
+			return errors.New("expected nats.<index>.<key>")
 		}
 		idx, err := strconv.Atoi(parts[1])
 		if err != nil {
-			return fmt.Errorf("nats index must be numeric")
+			return errors.New("nats index must be numeric")
 		}
 		for len(s.NATS) <= idx {
 			s.NATS = append(s.NATS, NATS{})
@@ -299,11 +309,11 @@ func applyEnvPath(s *Settings, parts []string, val string) error {
 		return setNATSField(&s.NATS[idx], strings.ToLower(parts[2]), val)
 	case "notify":
 		if len(parts) < 3 {
-			return fmt.Errorf("expected notify.<index>.<key>")
+			return errors.New("expected notify.<index>.<key>")
 		}
 		idx, err := strconv.Atoi(parts[1])
 		if err != nil {
-			return fmt.Errorf("notify index must be numeric")
+			return errors.New("notify index must be numeric")
 		}
 		for len(s.Notify) <= idx {
 			s.Notify = append(s.Notify, Notify{})
@@ -325,7 +335,7 @@ func applyEnvPath(s *Settings, parts []string, val string) error {
 //	mcp_keys.<idx>.{name,value}
 func applyAuthEnv(a *Auth, parts []string, val string) error {
 	if len(parts) == 0 {
-		return fmt.Errorf("expected auth.<key>")
+		return errors.New("expected auth.<key>")
 	}
 	switch strings.ToLower(parts[0]) {
 	case "enabled":
@@ -336,7 +346,7 @@ func applyAuthEnv(a *Auth, parts []string, val string) error {
 		a.Enabled = b
 	case "oidc":
 		if len(parts) != 2 {
-			return fmt.Errorf("expected auth.oidc.<key>")
+			return errors.New("expected auth.oidc.<key>")
 		}
 		switch strings.ToLower(parts[1]) {
 		case "issuer":
@@ -356,7 +366,7 @@ func applyAuthEnv(a *Auth, parts []string, val string) error {
 		return applyAccessEnv(&a.Access, parts[1:], val)
 	case "session":
 		if len(parts) != 2 {
-			return fmt.Errorf("expected auth.session.<key>")
+			return errors.New("expected auth.session.<key>")
 		}
 		switch strings.ToLower(parts[1]) {
 		case "secret":
@@ -380,11 +390,11 @@ func applyAuthEnv(a *Auth, parts []string, val string) error {
 		}
 	case "mcp_keys":
 		if len(parts) < 3 {
-			return fmt.Errorf("expected auth.mcp_keys.<index>.<key>")
+			return errors.New("expected auth.mcp_keys.<index>.<key>")
 		}
 		idx, err := strconv.Atoi(parts[1])
 		if err != nil {
-			return fmt.Errorf("mcp_keys index must be numeric")
+			return errors.New("mcp_keys index must be numeric")
 		}
 		for len(a.MCPKeys) <= idx {
 			a.MCPKeys = append(a.MCPKeys, MCPKey{})
@@ -408,7 +418,7 @@ func applyAuthEnv(a *Auth, parts []string, val string) error {
 // groups}). Slice values are comma-separated.
 func applyAccessEnv(acc *AuthAccess, parts []string, val string) error {
 	if len(parts) == 0 {
-		return fmt.Errorf("expected auth.access.<key>")
+		return errors.New("expected auth.access.<key>")
 	}
 	switch strings.ToLower(parts[0]) {
 	case "allowed_emails":
@@ -421,7 +431,7 @@ func applyAccessEnv(acc *AuthAccess, parts []string, val string) error {
 		acc.GroupsClaim = val
 	case "admin":
 		if len(parts) != 2 {
-			return fmt.Errorf("expected auth.access.admin.<key>")
+			return errors.New("expected auth.access.admin.<key>")
 		}
 		switch strings.ToLower(parts[1]) {
 		case "allowed_emails":
@@ -470,7 +480,7 @@ func setNotifyField(n *Notify, key, val string) error {
 func setNATSField(n *NATS, key, val string) error {
 	rv := reflect.ValueOf(n).Elem()
 	rt := rv.Type()
-	for i := 0; i < rt.NumField(); i++ {
+	for i := range rt.NumField() {
 		tag := rt.Field(i).Tag.Get("koanf")
 		if tag != key {
 			continue

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -52,7 +52,7 @@ func (a *admin) ping(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, a.log, err)
 		return
 	}
-	writeRawArray(w, http.StatusOK, out)
+	writeRawArray(w, out)
 }
 
 func (a *admin) pingEndpoint(w http.ResponseWriter, r *http.Request) {
@@ -70,7 +70,7 @@ func (a *admin) pingEndpoint(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, a.log, err)
 		return
 	}
-	writeRawArray(w, http.StatusOK, out)
+	writeRawArray(w, out)
 }
 
 func (a *admin) serverEndpoint(w http.ResponseWriter, r *http.Request) {
@@ -88,7 +88,7 @@ func (a *admin) serverEndpoint(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, a.log, err)
 		return
 	}
-	writeRaw(w, http.StatusOK, out)
+	writeRaw(w, out)
 }
 
 func (a *admin) accountEndpoint(w http.ResponseWriter, r *http.Request) {
@@ -106,7 +106,7 @@ func (a *admin) accountEndpoint(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, a.log, err)
 		return
 	}
-	writeRawArray(w, http.StatusOK, out)
+	writeRawArray(w, out)
 }
 
 func (a *admin) reload(w http.ResponseWriter, r *http.Request) {
@@ -119,7 +119,7 @@ func (a *admin) reload(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, a.log, err)
 		return
 	}
-	writeRaw(w, http.StatusOK, out)
+	writeRaw(w, out)
 }
 
 func (a *admin) lameDuck(w http.ResponseWriter, r *http.Request) {
@@ -132,7 +132,7 @@ func (a *admin) lameDuck(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, a.log, err)
 		return
 	}
-	writeRaw(w, http.StatusOK, out)
+	writeRaw(w, out)
 }
 
 type kickBody struct {
@@ -158,7 +158,7 @@ func (a *admin) kick(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, a.log, err)
 		return
 	}
-	writeRaw(w, http.StatusOK, out)
+	writeRaw(w, out)
 }
 
 func unknownEndpoint(w http.ResponseWriter, ep string, allowed []string) {

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -110,15 +110,16 @@ func writeJSON(w http.ResponseWriter, status int, body any) {
 
 // writeRaw streams an already-JSON payload back to the client without a
 // second encode pass. Used for everything that comes straight from NATS.
-func writeRaw(w http.ResponseWriter, status int, body json.RawMessage) {
+// Success-only (200) — error paths go through writeJSON/upstreamError.
+func writeRaw(w http.ResponseWriter, body json.RawMessage) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
+	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(body)
 }
 
-func writeRawArray(w http.ResponseWriter, status int, items []json.RawMessage) {
+func writeRawArray(w http.ResponseWriter, items []json.RawMessage) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
+	w.WriteHeader(http.StatusOK)
 	if len(items) == 0 {
 		_, _ = w.Write([]byte("[]"))
 		return
@@ -179,6 +180,7 @@ func requestLog(log *slog.Logger, next http.Handler) http.Handler {
 
 type statusRecorder struct {
 	http.ResponseWriter
+
 	status int
 }
 

--- a/internal/handler/jsm.go
+++ b/internal/handler/jsm.go
@@ -94,7 +94,7 @@ func (j *jsm) overview(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, j.log, err)
 		return
 	}
-	writeRawArray(w, http.StatusOK, out)
+	writeRawArray(w, out)
 }
 
 // overviewStream is an SSE endpoint that pushes a fresh overview on
@@ -169,7 +169,7 @@ func (j *jsm) listStreams(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, j.log, err)
 		return
 	}
-	writeRaw(w, http.StatusOK, out)
+	writeRaw(w, out)
 }
 
 func (j *jsm) streamInfo(w http.ResponseWriter, r *http.Request) {
@@ -182,7 +182,7 @@ func (j *jsm) streamInfo(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, j.log, err)
 		return
 	}
-	writeRaw(w, http.StatusOK, out)
+	writeRaw(w, out)
 }
 
 func (j *jsm) updateStream(w http.ResponseWriter, r *http.Request) {
@@ -213,7 +213,9 @@ func (j *jsm) updateStream(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		body["name"], _ = json.Marshal(stream)
+		// stream is a plain identifier; a quoted string is valid JSON, so we
+		// skip json.Marshal (which can't fail here anyway).
+		body["name"] = json.RawMessage(strconv.Quote(stream))
 	}
 
 	payload, err := json.Marshal(body)
@@ -226,7 +228,7 @@ func (j *jsm) updateStream(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, j.log, err)
 		return
 	}
-	writeRaw(w, http.StatusOK, out)
+	writeRaw(w, out)
 }
 
 func (j *jsm) purgeStream(w http.ResponseWriter, r *http.Request) {
@@ -242,7 +244,7 @@ func (j *jsm) purgeStream(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, j.log, err)
 		return
 	}
-	writeRaw(w, http.StatusOK, out)
+	writeRaw(w, out)
 }
 
 func (j *jsm) deleteStream(w http.ResponseWriter, r *http.Request) {
@@ -258,7 +260,7 @@ func (j *jsm) deleteStream(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, j.log, err)
 		return
 	}
-	writeRaw(w, http.StatusOK, out)
+	writeRaw(w, out)
 }
 
 func (j *jsm) listConsumers(w http.ResponseWriter, r *http.Request) {
@@ -271,7 +273,7 @@ func (j *jsm) listConsumers(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, j.log, err)
 		return
 	}
-	writeRaw(w, http.StatusOK, out)
+	writeRaw(w, out)
 }
 
 func (j *jsm) consumerInfo(w http.ResponseWriter, r *http.Request) {
@@ -284,7 +286,7 @@ func (j *jsm) consumerInfo(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, j.log, err)
 		return
 	}
-	writeRaw(w, http.StatusOK, out)
+	writeRaw(w, out)
 }
 
 func (j *jsm) metaStepdown(w http.ResponseWriter, r *http.Request) {
@@ -300,7 +302,7 @@ func (j *jsm) metaStepdown(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, j.log, err)
 		return
 	}
-	writeRaw(w, http.StatusOK, out)
+	writeRaw(w, out)
 }
 
 func (j *jsm) streamStepdown(w http.ResponseWriter, r *http.Request) {
@@ -316,7 +318,7 @@ func (j *jsm) streamStepdown(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, j.log, err)
 		return
 	}
-	writeRaw(w, http.StatusOK, out)
+	writeRaw(w, out)
 }
 
 func (j *jsm) consumerStepdown(w http.ResponseWriter, r *http.Request) {
@@ -332,7 +334,7 @@ func (j *jsm) consumerStepdown(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, j.log, err)
 		return
 	}
-	writeRaw(w, http.StatusOK, out)
+	writeRaw(w, out)
 }
 
 func (j *jsm) deleteConsumer(w http.ResponseWriter, r *http.Request) {
@@ -348,5 +350,5 @@ func (j *jsm) deleteConsumer(w http.ResponseWriter, r *http.Request) {
 		upstreamError(w, j.log, err)
 		return
 	}
-	writeRaw(w, http.StatusOK, out)
+	writeRaw(w, out)
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"log/slog"
 	"strings"
 	"testing"
@@ -47,7 +46,7 @@ func rpcLine(t *testing.T, id any, method string, params any) []byte {
 func runServer(t *testing.T, write bool, input [][]byte) []map[string]any {
 	t.Helper()
 	mgr := emptyManager(t)
-	srv := NewServer(mgr, slog.New(slog.NewTextHandler(io.Discard, nil)), write)
+	srv := NewServer(mgr, slog.New(slog.DiscardHandler), write)
 
 	var in bytes.Buffer
 	for _, line := range input {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/1995parham/cheshmhayash/internal/natsx"
@@ -654,7 +655,9 @@ func toolStreamUpdate(_ context.Context, s *Server, args json.RawMessage) (strin
 			return "", fmt.Errorf("config.name %q does not match stream %q", n, a.Stream)
 		}
 	} else {
-		a.Config["name"], _ = json.Marshal(a.Stream)
+		// Stream is a plain identifier; a quoted string is valid JSON, so we
+		// skip json.Marshal (which can't fail here anyway).
+		a.Config["name"] = json.RawMessage(strconv.Quote(a.Stream))
 	}
 	payload, err := json.Marshal(a.Config)
 	if err != nil {

--- a/internal/natsx/cluster.go
+++ b/internal/natsx/cluster.go
@@ -26,9 +26,16 @@ type Cluster struct {
 	discoveryTimeout time.Duration
 }
 
-func (c *Cluster) Name() string                    { return c.name }
-func (c *Cluster) Conn() *nats.Conn                { return c.nc }
-func (c *Cluster) RequestTimeout() time.Duration   { return c.requestTimeout }
+// Name is the configured cluster name.
+func (c *Cluster) Name() string { return c.name }
+
+// Conn is the live NATS connection for this cluster.
+func (c *Cluster) Conn() *nats.Conn { return c.nc }
+
+// RequestTimeout is the per-request deadline for this cluster.
+func (c *Cluster) RequestTimeout() time.Duration { return c.requestTimeout }
+
+// DiscoveryTimeout is the multi-responder discovery deadline for this cluster.
 func (c *Cluster) DiscoveryTimeout() time.Duration { return c.discoveryTimeout }
 
 // Connect dials a NATS server using the supplied config.
@@ -80,6 +87,8 @@ type Manager struct {
 	clusters map[string]*Cluster
 }
 
+// NewManager dials every configured cluster and returns a Manager keyed by
+// cluster name. It fails if any connection can't be established.
 func NewManager(ctx context.Context, cfgs []config.NATS) (*Manager, error) {
 	m := &Manager{clusters: make(map[string]*Cluster, len(cfgs))}
 	for _, cfg := range cfgs {

--- a/internal/natsx/log.go
+++ b/internal/natsx/log.go
@@ -2,11 +2,12 @@ package natsx
 
 import "log/slog"
 
-// defaultLogger returns the package's logger. Tests can override by setting
-// Logger; production code reuses slog.Default which the caller configured
-// in main.
+// Logger is the package-wide logger when non-nil. Tests set it to capture
+// output; production leaves it nil and falls back to slog.Default (which
+// main configures).
 var Logger *slog.Logger
 
+// defaultLogger returns Logger when set, otherwise slog.Default.
 func defaultLogger() *slog.Logger {
 	if Logger != nil {
 		return Logger

--- a/internal/notify/classify.go
+++ b/internal/notify/classify.go
@@ -62,7 +62,7 @@ func classify(subject string, raw []byte) *Event {
 // prefix, or "" if it isn't a JetStream advisory we care about.
 //
 // $JS.EVENT.ADVISORY.<rest>                          → <rest>
-// $SYS.ACCOUNT.<acct>.JETSTREAM.EVENT.ADVISORY.<rest> → <rest>
+// $SYS.ACCOUNT.<acct>.JETSTREAM.EVENT.ADVISORY.<rest> → <rest>.
 func jsAdvisorySuffix(subj string) string {
 	if s, ok := strings.CutPrefix(subj, "$JS.EVENT.ADVISORY."); ok {
 		return s
@@ -149,7 +149,7 @@ func replicaTail(replicas []string) string {
 	if len(replicas) == 0 {
 		return ""
 	}
-	return fmt.Sprintf(" · replicas: %s", strings.Join(replicas, ", "))
+	return " · replicas: " + strings.Join(replicas, ", ")
 }
 
 // str returns the named string field if present.


### PR DESCRIPTION
## Summary

Makes **golangci-lint the single source of truth** for Go linting and formatting, and enables as many linters as is practical.

- `golangci-lint run` (v2) already reports the `formatters` (gofmt/goimports) as issues **and** runs `go vet`, so the separate `go vet` + `gofmt` CI steps are removed.
- New `.golangci.yml`: `default: all`, disabling only the linters that fight this codebase's deliberate conventions or are pure style/ordering dogma — each with a one-line reason (`wsl`, `varnamelen`, `err113`, `wrapcheck`, `exhaustruct`, `depguard`/`gomodguard`, `mnd`, `funcorder`, `goconst`, complexity family, test-style dogma, …).
- `gosec` stays on with `G124` (operator-configurable cookie `Secure`) and `G705` (raw-JSON API passthrough) excluded; `exhaustive` treats a returning `default` as exhaustive; `frontend/node_modules` (vendored `flatted`) is excluded.
- golangci-lint version is no longer pinned in CI (`version: latest`).

## Code fixes for the newly-enabled linters
- **revive**: doc comments on exported `config`/`natsx` symbols + the `Role` const block.
- **errchkjson**: auth `writeJSON` checks the encode error; stream-name marshals use `strconv.Quote` (a quoted identifier is valid JSON and can't fail).
- **unparam**: `writeRaw`/`writeRawArray` drop the always-`200` status param.
- **intrange / perfsprint / sloglint / godot / embeddedstructfieldcheck / tagalign**: auto-applied via `golangci-lint run --fix`.

`golangci-lint run` → **0 issues**, `go build`/`go test` green, config `verify`d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)