### PR TITLE
chore: configure Dependabot (Go, npm, Actions, Docker)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,59 @@
+# Dependabot keeps every dependency surface current and opens grouped PRs.
+# Minor + patch bumps are batched into a single PR per ecosystem each week to
+# cut noise; major bumps come as their own PRs so they get individual review.
+# Commit prefixes match the repo's conventional-commit style so CI/changelogs
+# stay consistent.
+version: 2
+updates:
+  # ---- Go modules (root go.mod) --------------------------------------------
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      go-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ---- Frontend npm packages (frontend/package.json) -----------------------
+  - package-ecosystem: npm
+    directory: "/frontend"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ---- GitHub Actions used by the workflows --------------------------------
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # ---- Dockerfile base images (node / go / distroless) ---------------------
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "chore(docker)"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` so we get automated PRs for new dependency versions across **all four** surfaces in the repo:

| Ecosystem | Path | Tracks |
|---|---|---|
| `gomod` | `/` | `go.mod` direct + indirect modules |
| `npm` | `/frontend` | SPA dependencies + devDependencies |
| `github-actions` | `/` | action versions in `ci.yaml` / `release.yaml` |
| `docker` | `/` | `Dockerfile` base images (node, golang, distroless) |

### Noise control
- **Weekly** schedule (Mondays).
- Minor + patch bumps are **grouped into one PR per ecosystem**; majors arrive as individual PRs for separate review.
- `open-pull-requests-limit: 5` on the code ecosystems.
- Commit prefixes match the repo's conventional-commit style (`chore(deps)`, `chore(deps-dev)`, `chore(ci)`, `chore(docker)`).

> Note: Dependabot activates once this merges to `main` (config is read from the default branch). Helm chart deps aren't included — Dependabot has no Helm ecosystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)