### PR TITLE
Split the HTTP MCP server into its own binary

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,8 +28,7 @@ linters:
     - nilnil       # `return nil, nil` is intentional (e.g. extractGroups)
     # --- dependency / global policy --------------------------------------
     - depguard         # needs a bespoke import allowlist we don't want
-    - gomodguard       # ditto for modules (deprecated alias) — no policy
-    - gomodguard_v2    # ditto — no module blocklist policy
+    - gomodguard       # ditto for modules — no module blocklist policy
     - gochecknoglobals # version.Version, natsx.Logger are intentional
     # --- complexity (large config switch statements are deliberate) ------
     - cyclop

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,9 @@ the NATS client port (`:4222`).
 
 ```
 .
-├── main.go                        # entrypoint — HTTP server, or `-mcp` stdio MCP
+├── cmd/
+│   ├── cheshmhayash/              # entrypoint — HTTP dashboard (API + SPA, no /mcp)
+│   └── cheshmhayash-mcp/          # entrypoint — MCP server: stdio (default) or `-http`
 ├── internal/
 │   ├── config/                    # koanf loader: struct defaults → settings.toml → env
 │   ├── natsx/                     # NATS client + admin/jsm subjects + overview cache
@@ -48,30 +50,39 @@ Local dev — the Vite dev server proxies `/api` + `/healthz` to the Go
 process on `:1378`:
 
 ```sh
-go run .                              # backend on :1378
+go run ./cmd/cheshmhayash             # backend on :1378
 cd frontend && npm run dev            # UI on :5173 with HMR
 ```
 
-Production (single binary serves API + built SPA from `frontend/dist`):
+Production (the dashboard binary serves API + built SPA from `frontend/dist`):
 
 ```sh
 cd frontend && npm run build
-go build -o ./bin/cheshmhayash .
+go build -o ./bin/cheshmhayash ./cmd/cheshmhayash
 ./bin/cheshmhayash                    # http://127.0.0.1:1378
 ```
 
 Docker — `docker build -t cheshmhayash .` and `docker run -p 1378:1378
--v "$PWD/settings.toml:/app/settings.toml:ro" cheshmhayash`.
+-v "$PWD/settings.toml:/app/settings.toml:ro" cheshmhayash`. The image
+ships both binaries; the default ENTRYPOINT is the dashboard. Run the MCP
+server with `docker run … cheshmhayash /app/cheshmhayash-mcp -http`.
 
-MCP mode (stdio) — same binary with `-mcp`:
+MCP server — its own binary (`cmd/cheshmhayash-mcp`). The dashboard no
+longer serves `/mcp`; build/run the MCP binary instead:
 
 ```sh
-./bin/cheshmhayash -mcp                            # read-only tool set
-CHESHMHAYASH_MCP_WRITE=1 ./bin/cheshmhayash -mcp   # enables purge/delete/kick/reload/stepdown
+go build -o ./bin/cheshmhayash-mcp ./cmd/cheshmhayash-mcp
+
+./bin/cheshmhayash-mcp                              # stdio, read-only tool set
+CHESHMHAYASH_MCP_WRITE=1 ./bin/cheshmhayash-mcp     # stdio + purge/delete/kick/reload/stepdown
+./bin/cheshmhayash-mcp -http                        # Streamable HTTP /mcp on server.host:port
+./bin/cheshmhayash-mcp -http -addr :8080            # …or an explicit listen address
 ```
 
-It reuses `settings.toml`; logs go to stderr because stdout is the
-JSON-RPC channel.
+It reuses `settings.toml`; in stdio mode logs go to stderr because stdout
+is the JSON-RPC channel. In `-http` mode it serves `/mcp`, `/healthz`, and
+the RFC 9728 OAuth metadata, gated by the same `auth.mcp_*` config the
+dashboard used to apply.
 
 ## Configuration
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,15 +28,19 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 COPY . .
+# Two binaries: the dashboard (default ENTRYPOINT) and the MCP server
+# (cheshmhayash-mcp — stdio by default, `-http` for the Streamable HTTP
+# transport). Both ship in the image so one image can run either way.
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go build -ldflags="-s -w -X github.com/1995parham/cheshmhayash/internal/version.Version=${VERSION}" -o /out/cheshmhayash .
+    go build -ldflags="-s -w -X github.com/1995parham/cheshmhayash/internal/version.Version=${VERSION}" -o /out/ ./cmd/...
 
 # ---------- runtime -------------------------------------------------------
 FROM gcr.io/distroless/static-debian12:nonroot
 
 WORKDIR /app
 COPY --from=backend /out/cheshmhayash ./cheshmhayash
+COPY --from=backend /out/cheshmhayash-mcp ./cheshmhayash-mcp
 COPY --from=frontend /src/dist ./frontend/dist
 
 EXPOSE 1378

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ server responds with `428 Precondition Required`.
 - Per-cluster JSZ overview is refreshed in the background and pushed to
   the SPA over SSE — the panel updates in real time, with a small
   `live` / `polling` / `disconnected` indicator next to each view.
-- **MCP server** baked into the same binary. Speaks the Model Context
-  Protocol over both stdio (`cheshmhayash -mcp`) and HTTP Streamable
-  (`POST /mcp`) so LLM agents (Claude Desktop, Cursor, etc.) can
+- **MCP server** as its own binary (`cheshmhayash-mcp`). Speaks the Model
+  Context Protocol over both stdio (default) and HTTP Streamable
+  (`-http`, `POST /mcp`) so LLM agents (Claude Desktop, Cursor, etc.) can
   inspect and operate the cluster as tools. Read-only by default;
   destructive verbs gate on `CHESHMHAYASH_MCP_WRITE=1`.
 - **Webhook notifications** to Slack / Mattermost / Matrix (via hookshot
@@ -174,20 +174,29 @@ credentials grant; they will return `JetStream not enabled` (err_code
 ### Local
 
 ```sh
-# Backend
-go run .                              # serves API + built SPA on :1378
+# Backend (dashboard)
+go run ./cmd/cheshmhayash             # serves API + built SPA on :1378
 
 # Frontend (dev — separate terminal)
 cd frontend && npm install
 npm run dev                           # HMR on :5173, /api proxied to :1378
 ```
 
-For a single-binary production build:
+For a production build (the dashboard binary serves API + SPA):
 
 ```sh
 cd frontend && npm install && npm run build
-go build -o ./bin/cheshmhayash .
+go build -o ./bin/cheshmhayash ./cmd/cheshmhayash
 ./bin/cheshmhayash                    # http://127.0.0.1:1378
+```
+
+The MCP server is a separate binary (`cmd/cheshmhayash-mcp`) — stdio by
+default, `-http` for the Streamable HTTP transport:
+
+```sh
+go build -o ./bin/cheshmhayash-mcp ./cmd/cheshmhayash-mcp
+./bin/cheshmhayash-mcp                # stdio (Claude Desktop, Cursor, …)
+./bin/cheshmhayash-mcp -http          # POST /mcp on server.host:port
 ```
 
 ### Docker
@@ -208,7 +217,7 @@ artifact to GHCR on every tagged release.
 # install from GHCR
 helm install panel \
   oci://ghcr.io/1995parham/cheshmhayash-chart \
-  --version 1.0.0 \
+  --version 1.8.0 \
   -f my-values.yaml
 
 # or from a local checkout
@@ -231,19 +240,32 @@ clusters:
         passwordKey: password
 ```
 
+The chart deploys the dashboard only. The MCP HTTP server is a separate
+binary, so it ships as an opt-in workload — set `mcp.enabled: true` to add
+a `cheshmhayash-mcp -http` Deployment + Service. It reuses the same image,
+`settings.toml` and NATS auth; `/mcp` auth is configured under
+`auth.mcpKeys` / `auth.mcpOauth` / `auth.mcpJwt`, and write tools gate on
+`mcp.write`:
+
+```yaml
+mcp:
+  enabled: true
+  port: 8080
+  write: false
+```
+
 ## Development
 
 ```sh
-# backend
-go fmt ./...
-go vet ./...
-go test -race ./...
+# backend — golangci-lint is the single source of truth for Go: it runs
+# gofmt/goimports and go vet too, so there are no separate fmt/vet steps.
 golangci-lint run
+go test -race ./...
 
-# frontend
+# frontend — Biome is the single lint + format tool (replaces ESLint/Prettier)
 cd frontend
+npm run ci          # biome lint + format check
 npm run typecheck
-npm run lint
 npm run build
 ```
 

--- a/chart/cheshmhayash-chart/Chart.yaml
+++ b/chart/cheshmhayash-chart/Chart.yaml
@@ -4,7 +4,7 @@ description: NATS administration dashboard served over the NATS protocol itself.
 type: application
 
 # Chart version — bump on every chart change (independent of appVersion).
-version: 1.7.0
+version: 1.8.0
 
 # Application version — matches the cheshmhayash binary release. The
 # release.yaml workflow rewrites this to the pushed tag's version.
@@ -41,5 +41,5 @@ annotations:
     - name: nats.io
       url: https://nats.io
   artifacthub.io/changes: |
-    - kind: added
-      description: "`auth.mcpJwt.enabled`: third /mcp auth path — accept a bearer JWT and read its identity claims WITHOUT verifying the token (no signature/issuer/audience/expiry check). Claims still resolve a role through the `auth.access` allowlists. For deployments where a trusted gateway already validated the token; anyone reaching /mcp directly can forge claims, so keep the endpoint gateway-only. Off by default; static `mcpKeys` and `mcpOauth` keep working alongside."
+    - kind: changed
+      description: "The MCP server is now a separate binary (`cheshmhayash-mcp`); the dashboard no longer serves `/mcp`. Set `mcp.enabled: true` to run the Streamable HTTP transport as its own Deployment + Service (reuses the same image, settings.toml and NATS auth; `auth.mcp*` keys configure /mcp auth as before). Write tools gate on `mcp.write`."

--- a/chart/cheshmhayash-chart/templates/NOTES.txt
+++ b/chart/cheshmhayash-chart/templates/NOTES.txt
@@ -28,6 +28,18 @@ Reach the panel:
 Health check:
   kubectl --namespace {{ .Release.Namespace }} exec deploy/{{ include "cheshmhayash-chart.fullname" . }} \
     -- wget -qO- http://127.0.0.1:{{ .Values.server.port }}/healthz && echo "ok"
+{{- if .Values.mcp.enabled }}
+
+MCP server (Streamable HTTP transport) is enabled as a separate workload:
+  Service: {{ include "cheshmhayash-chart.mcp.fullname" . }}:{{ .Values.mcp.service.port }} → /mcp
+  kubectl --namespace {{ .Release.Namespace }} port-forward \
+    svc/{{ include "cheshmhayash-chart.mcp.fullname" . }} {{ .Values.mcp.port }}:{{ .Values.mcp.service.port }}
+  Write tools: {{ if .Values.mcp.write }}ENABLED (CHESHMHAYASH_MCP_WRITE=1){{ else }}disabled (set mcp.write=true){{ end }}
+{{- else }}
+
+NOTE: the dashboard no longer serves /mcp. Set `mcp.enabled: true` to run
+the MCP HTTP server (cheshmhayash-mcp) as its own Deployment + Service.
+{{- end }}
 
 Helm tests:
   helm test {{ .Release.Name }} --namespace {{ .Release.Namespace }}

--- a/chart/cheshmhayash-chart/templates/_helpers.tpl
+++ b/chart/cheshmhayash-chart/templates/_helpers.tpl
@@ -53,6 +53,115 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+MCP workload name — the dashboard fullname with a `-mcp` suffix.
+*/}}
+{{- define "cheshmhayash-chart.mcp.fullname" -}}
+{{- printf "%s-mcp" (include "cheshmhayash-chart.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Immutable selector subset for the MCP workload. Distinct from the dashboard
+selector so the two Deployments never adopt each other's pods.
+*/}}
+{{- define "cheshmhayash-chart.mcp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cheshmhayash-chart.name" . }}-mcp
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Recommended labels for the MCP workload (component: mcp).
+*/}}
+{{- define "cheshmhayash-chart.mcp.labels" -}}
+helm.sh/chart: {{ include "cheshmhayash-chart.chart" . }}
+{{ include "cheshmhayash-chart.mcp.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/component: mcp
+app.kubernetes.io/part-of: nats
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Per-cluster NATS auth env (CHESHMHAYASH__NATS__i__USER/PASSWORD). Shared by
+the dashboard and MCP Deployments — both open the same NATS connections.
+*/}}
+{{- define "cheshmhayash-chart.natsAuthEnv" -}}
+{{- range $i, $c := .Values.clusters }}
+{{- if and $c.auth $c.auth.existingSecret }}
+- name: CHESHMHAYASH__NATS__{{ $i }}__USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ $c.auth.existingSecret.name }}
+      key: {{ $c.auth.existingSecret.userKey | default "user" }}
+- name: CHESHMHAYASH__NATS__{{ $i }}__PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ $c.auth.existingSecret.name }}
+      key: {{ $c.auth.existingSecret.passwordKey | default "password" }}
+{{- else if and $c.auth $c.auth.userPassword }}
+- name: CHESHMHAYASH__NATS__{{ $i }}__USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "cheshmhayash-chart.secretName" $ }}
+      key: {{ $c.name }}-user
+- name: CHESHMHAYASH__NATS__{{ $i }}__PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "cheshmhayash-chart.secretName" $ }}
+      key: {{ $c.name }}-password
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+MCP static bearer-key env (CHESHMHAYASH__AUTH__MCP_KEYS__i__VALUE). Consumed
+by the MCP Deployment, which is the only workload that serves /mcp.
+*/}}
+{{- define "cheshmhayash-chart.mcpKeysEnv" -}}
+{{- range $i, $k := .Values.auth.mcpKeys }}
+- name: CHESHMHAYASH__AUTH__MCP_KEYS__{{ $i }}__VALUE
+  valueFrom:
+    secretKeyRef:
+      {{- if $k.existingSecret }}
+      name: {{ $k.existingSecret.name }}
+      key: {{ $k.existingSecret.key }}
+      {{- else }}
+      name: {{ include "cheshmhayash-chart.secretName" $ }}
+      key: mcp-key-{{ $i }}
+      {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+NATS creds-file volumeMounts (shared by dashboard + MCP).
+*/}}
+{{- define "cheshmhayash-chart.credsVolumeMounts" -}}
+{{- range $i, $c := .Values.clusters }}
+{{- if and $c.auth $c.auth.credsFileSecret }}
+- name: creds-{{ $c.name }}
+  mountPath: /etc/cheshmhayash/creds/{{ $c.name }}.creds
+  subPath: {{ $c.auth.credsFileSecret.key }}
+  readOnly: true
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+NATS creds-file volumes (shared by dashboard + MCP).
+*/}}
+{{- define "cheshmhayash-chart.credsVolumes" -}}
+{{- range $i, $c := .Values.clusters }}
+{{- if and $c.auth $c.auth.credsFileSecret }}
+- name: creds-{{ $c.name }}
+  secret:
+    secretName: {{ $c.auth.credsFileSecret.name }}
+    defaultMode: 0400
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 ServiceAccount name in use.
 */}}
 {{- define "cheshmhayash-chart.serviceAccountName" -}}

--- a/chart/cheshmhayash-chart/templates/deployment.yaml
+++ b/chart/cheshmhayash-chart/templates/deployment.yaml
@@ -67,34 +67,9 @@ spec:
             {{- end }}
           {{- end }}
           {{- $hasAppAuthEnv := and .Values.auth.enabled true }}
-          {{- $hasMCPKeyEnv := gt (len .Values.auth.mcpKeys) 0 }}
-          {{- if or $hasAuthEnv $hasNotifyEnv $hasAppAuthEnv $hasMCPKeyEnv .Values.extraEnv }}
+          {{- if or $hasAuthEnv $hasNotifyEnv $hasAppAuthEnv .Values.extraEnv }}
           env:
-            {{- range $i, $c := .Values.clusters }}
-            {{- if and $c.auth $c.auth.existingSecret }}
-            - name: CHESHMHAYASH__NATS__{{ $i }}__USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $c.auth.existingSecret.name }}
-                  key: {{ $c.auth.existingSecret.userKey | default "user" }}
-            - name: CHESHMHAYASH__NATS__{{ $i }}__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $c.auth.existingSecret.name }}
-                  key: {{ $c.auth.existingSecret.passwordKey | default "password" }}
-            {{- else if and $c.auth $c.auth.userPassword }}
-            - name: CHESHMHAYASH__NATS__{{ $i }}__USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "cheshmhayash-chart.secretName" $ }}
-                  key: {{ $c.name }}-user
-            - name: CHESHMHAYASH__NATS__{{ $i }}__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "cheshmhayash-chart.secretName" $ }}
-                  key: {{ $c.name }}-password
-            {{- end }}
-            {{- end }}
+            {{- include "cheshmhayash-chart.natsAuthEnv" . | nindent 12 }}
             {{- range $i, $n := .Values.notify }}
             {{- if $n.urlSecret }}
             - name: CHESHMHAYASH__NOTIFY__{{ $i }}__URL
@@ -128,18 +103,6 @@ spec:
                   {{- else }}
                   name: {{ include "cheshmhayash-chart.secretName" . }}
                   key: session-secret
-                  {{- end }}
-            {{- end }}
-            {{- range $i, $k := .Values.auth.mcpKeys }}
-            - name: CHESHMHAYASH__AUTH__MCP_KEYS__{{ $i }}__VALUE
-              valueFrom:
-                secretKeyRef:
-                  {{- if $k.existingSecret }}
-                  name: {{ $k.existingSecret.name }}
-                  key: {{ $k.existingSecret.key }}
-                  {{- else }}
-                  name: {{ include "cheshmhayash-chart.secretName" $ }}
-                  key: mcp-key-{{ $i }}
                   {{- end }}
             {{- end }}
             {{- with .Values.extraEnv }}
@@ -185,14 +148,7 @@ spec:
               mountPath: /app/settings.toml
               subPath: settings.toml
               readOnly: true
-            {{- range $i, $c := .Values.clusters }}
-            {{- if and $c.auth $c.auth.credsFileSecret }}
-            - name: creds-{{ $c.name }}
-              mountPath: /etc/cheshmhayash/creds/{{ $c.name }}.creds
-              subPath: {{ $c.auth.credsFileSecret.key }}
-              readOnly: true
-            {{- end }}
-            {{- end }}
+            {{- include "cheshmhayash-chart.credsVolumeMounts" . | nindent 12 }}
             # readOnlyRootFilesystem is true, so anything the binary writes
             # has to land on an emptyDir.
             - name: tmp
@@ -207,14 +163,7 @@ spec:
         - name: config
           configMap:
             name: {{ include "cheshmhayash-chart.configMapName" . }}
-        {{- range $i, $c := .Values.clusters }}
-        {{- if and $c.auth $c.auth.credsFileSecret }}
-        - name: creds-{{ $c.name }}
-          secret:
-            secretName: {{ $c.auth.credsFileSecret.name }}
-            defaultMode: 0400
-        {{- end }}
-        {{- end }}
+        {{- include "cheshmhayash-chart.credsVolumes" . | nindent 8 }}
         - name: tmp
           emptyDir:
             sizeLimit: 16Mi

--- a/chart/cheshmhayash-chart/templates/mcp-deployment.yaml
+++ b/chart/cheshmhayash-chart/templates/mcp-deployment.yaml
@@ -1,0 +1,140 @@
+{{- if .Values.mcp.enabled }}
+{{- /*
+Standalone MCP server. Runs the cheshmhayash-mcp binary in `-http` mode so
+the Streamable HTTP transport at /mcp is served by its own workload — the
+dashboard no longer serves /mcp. Reuses the same image, settings.toml
+ConfigMap and NATS auth as the dashboard; /mcp auth (static keys / OIDC /
+unverified JWT) is configured under `auth.mcp*` in the shared settings.
+*/}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cheshmhayash-chart.mcp.fullname" . }}
+  labels:
+    {{- include "cheshmhayash-chart.mcp.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.mcp.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    {{- toYaml .Values.strategy | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "cheshmhayash-chart.mcp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "cheshmhayash-chart.mcp.selectorLabels" . | nindent 8 }}
+        {{- with .Values.mcp.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- if .Values.restartOnConfigChange }}
+        checksum/config: {{ include "cheshmhayash-chart.settingsToml" . | sha256sum }}
+        {{- end }}
+        {{- with .Values.mcp.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "cheshmhayash-chart.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}-mcp
+          image: {{ include "cheshmhayash-chart.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command: ["/app/cheshmhayash-mcp"]
+          args: ["-http", "-addr", ":{{ .Values.mcp.port }}"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.mcp.port }}
+              protocol: TCP
+          {{- $hasNatsAuthEnv := false }}
+          {{- range $c := .Values.clusters }}
+            {{- if and $c.auth (or $c.auth.existingSecret $c.auth.userPassword) }}
+              {{- $hasNatsAuthEnv = true }}
+            {{- end }}
+          {{- end }}
+          {{- $hasMCPKeyEnv := gt (len .Values.auth.mcpKeys) 0 }}
+          {{- if or $hasNatsAuthEnv $hasMCPKeyEnv .Values.mcp.write .Values.mcp.extraEnv }}
+          env:
+            {{- if .Values.mcp.write }}
+            - name: CHESHMHAYASH_MCP_WRITE
+              value: "1"
+            {{- end }}
+            {{- include "cheshmhayash-chart.natsAuthEnv" . | nindent 12 }}
+            {{- include "cheshmhayash-chart.mcpKeysEnv" . | nindent 12 }}
+            {{- with .Values.mcp.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+            successThreshold: {{ .Values.probes.readiness.successThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml (.Values.mcp.resources | default .Values.resources) | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/settings.toml
+              subPath: settings.toml
+              readOnly: true
+            {{- include "cheshmhayash-chart.credsVolumeMounts" . | nindent 12 }}
+            # readOnlyRootFilesystem is true, so anything the binary writes
+            # has to land on an emptyDir.
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "cheshmhayash-chart.configMapName" . }}
+        {{- include "cheshmhayash-chart.credsVolumes" . | nindent 8 }}
+        - name: tmp
+          emptyDir:
+            sizeLimit: 16Mi
+      {{- with .Values.mcp.nodeSelector | default .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mcp.affinity | default .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mcp.tolerations | default .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/chart/cheshmhayash-chart/templates/mcp-service.yaml
+++ b/chart/cheshmhayash-chart/templates/mcp-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.mcp.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cheshmhayash-chart.mcp.fullname" . }}
+  labels:
+    {{- include "cheshmhayash-chart.mcp.labels" . | nindent 4 }}
+  {{- with .Values.mcp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.mcp.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.mcp.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "cheshmhayash-chart.mcp.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/chart/cheshmhayash-chart/values.yaml
+++ b/chart/cheshmhayash-chart/values.yaml
@@ -124,6 +124,38 @@ service:
   # Use a specific nodePort/targetPort if you switch type: NodePort.
   annotations: {}
 
+# ---- MCP server ------------------------------------------------------------
+# The MCP server is a separate binary (cheshmhayash-mcp). The dashboard no
+# longer serves /mcp; enable this to run the Streamable HTTP transport as its
+# own Deployment + Service. It reuses the same image, settings.toml and NATS
+# auth; /mcp auth is configured under `auth.mcpKeys` / `auth.mcpOauth` /
+# `auth.mcpJwt` below (shared settings). Write tools are off unless
+# `mcp.write: true` (sets CHESHMHAYASH_MCP_WRITE=1).
+#
+# Pod security, serviceAccount, image, probes and update strategy are shared
+# with the dashboard; scheduling (nodeSelector/affinity/tolerations) and
+# resources fall back to the dashboard values when left empty.
+mcp:
+  enabled: false
+  replicaCount: 1
+  # Container + Service port for the HTTP transport (passed as `-addr :PORT`).
+  port: 8080
+  # Register the destructive MCP tools (purge/delete/kick/reload/stepdown).
+  write: false
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+  # Defaults to the top-level `resources` when empty.
+  resources: {}
+  podAnnotations: {}
+  podLabels: {}
+  extraEnv: []
+  # Default to the top-level scheduling values when empty.
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
 # --- ingress routing ------------------------------------------------------
 # The chart ships two ingress mechanisms; enable whichever fits your cluster.
 # Don't enable both with the same hostname — most controllers (including
@@ -268,6 +300,10 @@ notify: []
 # before this section was added. MCP keys work independently — list any
 # entry under `mcpKeys` to require a bearer token on /mcp, regardless of
 # whether OIDC is on.
+#
+# The `mcp*` keys below configure the /mcp endpoint, which is now served by
+# the separate MCP workload (`mcp.enabled` above), not the dashboard. They
+# have no effect unless `mcp.enabled: true`.
 #
 # Sensitive fields (`oidc.clientSecret`, `session.secret`, MCP key values)
 # are sourced from a Secret. The chart can either create + populate that

--- a/cmd/cheshmhayash-mcp/main.go
+++ b/cmd/cheshmhayash-mcp/main.go
@@ -1,0 +1,171 @@
+// Command cheshmhayash-mcp runs the cheshmhayash MCP server. By default it
+// speaks JSON-RPC 2.0 over stdio (for local LLM tool-use, e.g. Claude
+// Desktop). With -http it instead serves the MCP Streamable HTTP transport
+// at /mcp on its own listener, reusing the same NATS manager, config, and
+// auth model as the dashboard binary.
+//
+// Both transports share mcp.NewServer; write tools are gated by the
+// CHESHMHAYASH_MCP_WRITE env var (startup-time), not by identity.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/1995parham/cheshmhayash/internal/auth"
+	"github.com/1995parham/cheshmhayash/internal/config"
+	"github.com/1995parham/cheshmhayash/internal/handler"
+	"github.com/1995parham/cheshmhayash/internal/mcp"
+	"github.com/1995parham/cheshmhayash/internal/natsx"
+)
+
+const shutdownTimeout = 10 * time.Second
+
+// mcpKeyMatchers converts the config slice into the loose auth.KeyMatcher
+// shape — keeps the auth package independent of config.
+func mcpKeyMatchers(in []config.MCPKey) []auth.KeyMatcher {
+	out := make([]auth.KeyMatcher, 0, len(in))
+	for _, k := range in {
+		out = append(out, auth.KeyMatcher{Name: k.Name, Value: k.Value})
+	}
+	return out
+}
+
+func main() {
+	httpMode := flag.Bool("http", false, "serve the MCP Streamable HTTP transport instead of stdio")
+	addr := flag.String("addr", "", "listen address for -http mode (default: server.host:server.port from config)")
+	flag.Parse()
+
+	logLevel := slog.LevelInfo
+	if v := os.Getenv("LOG_LEVEL"); v != "" {
+		_ = logLevel.UnmarshalText([]byte(v))
+	}
+	// stdout is the JSON-RPC channel in stdio mode — every byte of log noise
+	// has to go to stderr instead.
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel}))
+	slog.SetDefault(log)
+	natsx.Logger = log
+
+	var err error
+	if *httpMode {
+		err = runHTTP(log, *addr)
+	} else {
+		err = runStdio(log)
+	}
+	if err != nil {
+		log.Error("fatal", "err", err)
+		os.Exit(1)
+	}
+}
+
+func runStdio(log *slog.Logger) error {
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	settings, err := config.Load()
+	if err != nil {
+		return err
+	}
+	mgr, err := natsx.NewManager(ctx, settings.NATS)
+	if err != nil {
+		return err
+	}
+	defer mgr.Close()
+
+	write := os.Getenv("CHESHMHAYASH_MCP_WRITE") == "1"
+	log.Info("starting mcp server",
+		"transport", "stdio",
+		"clusters", len(settings.NATS),
+		"write_enabled", write,
+	)
+	srv := mcp.NewServer(mgr, log, write)
+	if err := srv.RunStdio(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		return err
+	}
+	return nil
+}
+
+func runHTTP(log *slog.Logger, addr string) error {
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	settings, err := config.Load()
+	if err != nil {
+		return err
+	}
+	for _, c := range settings.NATS {
+		log.Info("connecting", "cluster", c.Name, "url", c.URL)
+	}
+	mgr, err := natsx.NewManager(ctx, settings.NATS)
+	if err != nil {
+		return err
+	}
+	defer mgr.Close()
+
+	write := os.Getenv("CHESHMHAYASH_MCP_WRITE") == "1"
+	mcpServer := mcp.NewServer(mgr, log, write)
+
+	// Optional OIDC. When Auth.Enabled is false this stays nil and /mcp is
+	// reachable without a token (unless static MCP keys are configured).
+	var authn *auth.Authenticator
+	if settings.Auth.Enabled {
+		authn, err = auth.New(ctx, settings.Auth, log)
+		if err != nil {
+			return err
+		}
+	}
+	mcpKeys := mcpKeyMatchers(settings.Auth.MCPKeys)
+	if len(mcpKeys) > 0 {
+		log.Info("mcp http bearer auth enabled", "keys", len(mcpKeys))
+	}
+	if settings.Auth.MCPOAuth.Enabled {
+		log.Info("mcp http oidc auth enabled",
+			"issuer", settings.Auth.OIDC.Issuer,
+			"resource", settings.Auth.MCPOAuth.Resource,
+		)
+	}
+	if settings.Auth.MCPJWT.Enabled {
+		// Deliberately loud: claims on /mcp are trusted without verification.
+		log.Warn("mcp http unverified-jwt auth enabled — token claims are NOT verified; a gateway must validate tokens upstream")
+	}
+
+	if addr == "" {
+		addr = settings.Server.Addr()
+	}
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           handler.MCPMux(mcpServer, authn, mcpKeys, log),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		log.Info("starting mcp server",
+			"transport", "http",
+			"address", addr,
+			"path", "/mcp",
+			"clusters", len(settings.NATS),
+			"write_enabled", write,
+		)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Error("http server", "err", err)
+			cancel()
+		}
+	}()
+
+	<-ctx.Done()
+	log.Info("shutting down")
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer shutdownCancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Warn("shutdown", "err", err)
+	}
+	return nil
+}

--- a/cmd/cheshmhayash/main.go
+++ b/cmd/cheshmhayash/main.go
@@ -1,13 +1,13 @@
-// cheshmhayash is a NATS administration dashboard exposed over HTTP. It
-// reuses one long-lived NATS connection per configured cluster and proxies
+// Command cheshmhayash is a NATS administration dashboard exposed over HTTP.
+// It reuses one long-lived NATS connection per configured cluster and proxies
 // requests through `$SYS.REQ.*` and `$JS.API.*` so the same auth model
-// natscli uses also applies here.
+// natscli uses also applies here. The MCP server (stdio and HTTP transports)
+// lives in the separate cheshmhayash-mcp binary.
 package main
 
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -19,7 +19,6 @@ import (
 	"github.com/1995parham/cheshmhayash/internal/auth"
 	"github.com/1995parham/cheshmhayash/internal/config"
 	"github.com/1995parham/cheshmhayash/internal/handler"
-	"github.com/1995parham/cheshmhayash/internal/mcp"
 	"github.com/1995parham/cheshmhayash/internal/natsx"
 	"github.com/1995parham/cheshmhayash/internal/notify"
 )
@@ -52,42 +51,21 @@ func notifyConfigs(in []config.Notify) []notify.ProviderConfig {
 	return out
 }
 
-// mcpKeyMatchers converts the config slice into the loose auth.KeyMatcher
-// shape — keeps the auth package independent of config.
-func mcpKeyMatchers(in []config.MCPKey) []auth.KeyMatcher {
-	out := make([]auth.KeyMatcher, 0, len(in))
-	for _, k := range in {
-		out = append(out, auth.KeyMatcher{Name: k.Name, Value: k.Value})
-	}
-	return out
-}
-
 const (
 	frontendDir     = "frontend/dist"
 	shutdownTimeout = 10 * time.Second
 )
 
 func main() {
-	mcpMode := flag.Bool("mcp", false, "run as a stdio MCP server instead of the HTTP API")
-	flag.Parse()
-
 	logLevel := slog.LevelInfo
 	if v := os.Getenv("LOG_LEVEL"); v != "" {
 		_ = logLevel.UnmarshalText([]byte(v))
 	}
-	// In MCP mode, stdout is the JSON-RPC channel — every byte of log noise
-	// has to go to stderr instead.
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel}))
 	slog.SetDefault(log)
 	natsx.Logger = log
 
-	var err error
-	if *mcpMode {
-		err = runMCP(log)
-	} else {
-		err = run(log)
-	}
-	if err != nil {
+	if err := run(log); err != nil {
 		log.Error("fatal", "err", err)
 		os.Exit(1)
 	}
@@ -132,12 +110,6 @@ func run(log *slog.Logger) error {
 	}
 	defer notifier.Close()
 
-	// Expose MCP over HTTP at /mcp using the same NATS manager. Write mode
-	// is opt-in via env so the HTTP endpoint defaults to read-only.
-	mcpWrite := os.Getenv("CHESHMHAYASH_MCP_WRITE") == "1"
-	mcpServer := mcp.NewServer(mgr, log, mcpWrite)
-	log.Info("mcp http transport enabled", "path", "/mcp", "write_enabled", mcpWrite)
-
 	// Optional OIDC. When Auth.Enabled is false this stays nil and the API
 	// behaves like it did before — backward-compatible default.
 	var authn *auth.Authenticator
@@ -161,20 +133,6 @@ func run(log *slog.Logger) error {
 			"admin_allowlist_set", !admin.IsEmpty(),
 		)
 	}
-	mcpKeys := mcpKeyMatchers(settings.Auth.MCPKeys)
-	if len(mcpKeys) > 0 {
-		log.Info("mcp http bearer auth enabled", "keys", len(mcpKeys))
-	}
-	if settings.Auth.MCPOAuth.Enabled {
-		log.Info("mcp http oidc auth enabled",
-			"issuer", settings.Auth.OIDC.Issuer,
-			"resource", settings.Auth.MCPOAuth.Resource,
-		)
-	}
-	if settings.Auth.MCPJWT.Enabled {
-		// Deliberately loud: claims on /mcp are trusted without verification.
-		log.Warn("mcp http unverified-jwt auth enabled — token claims are NOT verified; a gateway must validate tokens upstream")
-	}
 
 	// Background JSZ overview cache. /api/jsm/.../overview reads from
 	// here, /api/jsm/.../overview/stream subscribes to refresh ticks.
@@ -184,7 +142,7 @@ func run(log *slog.Logger) error {
 
 	srv := &http.Server{
 		Addr:              settings.Server.Addr(),
-		Handler:           handler.Mux(mgr, overviewCache, frontendDir, log, mcpServer, authn, mcpKeys),
+		Handler:           handler.Mux(mgr, overviewCache, frontendDir, log, authn),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
@@ -206,32 +164,6 @@ func run(log *slog.Logger) error {
 	defer shutdownCancel()
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		log.Warn("shutdown", "err", err)
-	}
-	return nil
-}
-
-func runMCP(log *slog.Logger) error {
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer cancel()
-
-	settings, err := config.Load()
-	if err != nil {
-		return err
-	}
-	mgr, err := natsx.NewManager(ctx, settings.NATS)
-	if err != nil {
-		return err
-	}
-	defer mgr.Close()
-
-	write := os.Getenv("CHESHMHAYASH_MCP_WRITE") == "1"
-	log.Info("starting mcp server",
-		"clusters", len(settings.NATS),
-		"write_enabled", write,
-	)
-	srv := mcp.NewServer(mgr, log, write)
-	if err := srv.RunStdio(ctx); err != nil && !errors.Is(err, context.Canceled) {
-		return err
 	}
 	return nil
 }

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -17,24 +17,21 @@ import (
 )
 
 // Mux returns a fully wired ServeMux covering /api/admin, /api/jsm,
-// /healthz, an optional /mcp endpoint, and a static-file SPA fallback at /.
+// /healthz, and a static-file SPA fallback at /. The HTTP MCP transport
+// lives in its own binary (cheshmhayash-mcp -http); see MCPMux.
 //
-// mcpHandler is optional — pass nil to skip /mcp registration. Likewise
 // cache is optional; when nil, /api/jsm/.../overview falls back to a
 // live NATS call on every request and /overview/stream returns 503.
 //
 // authn is optional. When non-nil and Enabled, /api/auth/* endpoints are
 // registered and all /api/* routes are wrapped in the session-check
-// middleware. mcpKeys, when non-empty, gates /mcp with bearer-token auth
-// (independent of authn — MCP keys work even with OIDC disabled).
+// middleware.
 func Mux(
 	mgr *natsx.Manager,
 	cache *natsx.OverviewCache,
 	staticDir string,
 	logger *slog.Logger,
-	mcpHandler http.Handler,
 	authn *auth.Authenticator,
-	mcpKeys []auth.KeyMatcher,
 ) http.Handler {
 	mux := http.NewServeMux()
 
@@ -58,14 +55,6 @@ func Mux(
 		authn.Register(mux)
 	}
 
-	if mcpHandler != nil {
-		mux.Handle("/mcp", authn.MCPMiddleware(mcpKeys, mcpHandler))
-		// Advertise OAuth 2.0 Protected Resource Metadata (RFC 9728) so MCP
-		// clients can discover the OIDC authorization server. No-op unless
-		// auth.mcp_oauth is enabled.
-		authn.RegisterMCPMetadata(mux)
-	}
-
 	spa(mux, staticDir)
 
 	var inner http.Handler = mux
@@ -73,6 +62,36 @@ func Mux(
 		inner = authn.Middleware(mux)
 	}
 	return cors(requestLog(logger, inner))
+}
+
+// MCPMux builds the HTTP handler for the standalone MCP server
+// (cheshmhayash-mcp -http): a liveness probe at /healthz, the MCP
+// Streamable HTTP transport at /mcp, and the RFC 9728 OAuth metadata
+// endpoints. It shares the dashboard's CORS + request-logging wrappers.
+//
+// authn is optional (nil ⇒ no auth). mcpKeys, when non-empty, gates /mcp
+// with bearer-token auth independently of authn — MCP keys work even with
+// OIDC disabled. The well-known metadata is registered only when
+// auth.mcp_oauth is enabled.
+func MCPMux(
+	mcpHandler http.Handler,
+	authn *auth.Authenticator,
+	mcpKeys []auth.KeyMatcher,
+	logger *slog.Logger,
+) http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	mux.Handle("/mcp", authn.MCPMiddleware(mcpKeys, mcpHandler))
+	// Advertise OAuth 2.0 Protected Resource Metadata (RFC 9728) so MCP
+	// clients can discover the OIDC authorization server. No-op unless
+	// auth.mcp_oauth is enabled.
+	authn.RegisterMCPMetadata(mux)
+
+	return cors(requestLog(logger, mux))
 }
 
 // spa serves the built SPA from staticDir. Unknown paths fall back to


### PR DESCRIPTION
Separates the MCP server from the dashboard so each is its own binary, and fixes a broken golangci-lint config along the way.

## Changes
- **fix(lint)**: drop the bogus `gomodguard_v2` entry from `.golangci.yml` — it isn't a real linter, so golangci-lint aborted with "unknown linters" (CI lint job was red). `golangci-lint run ./...` now reports 0 issues.
- **refactor**: move entrypoints under `cmd/`. `cheshmhayash` serves only the HTTP dashboard (API + SPA); the MCP server lives in `cheshmhayash-mcp` — stdio by default, `-http` (with optional `-addr`) for the Streamable HTTP transport. `handler.MCPMux` builds the standalone `/mcp` mux. The dashboard no longer serves `/mcp`.
- **build(docker)**: build + ship both binaries; default ENTRYPOINT stays the dashboard.
- **feat(chart)**: opt-in `mcp.enabled` Deployment + Service running `cheshmhayash-mcp -http`, reusing the same image/settings/NATS auth. Chart bumped to 1.8.0.
- **docs**: CLAUDE.md + README updated; backend dev steps collapsed to `golangci-lint run` + `go test` (golangci-lint already runs gofmt/goimports + go vet).

Both binaries share the same `config.Load()` (koanf: struct defaults → `settings.toml` → env).

## Upgrade note
`mcp.enabled` defaults to **false**, so a plain `helm upgrade` removes the in-cluster `/mcp` (it used to ride on the dashboard). Set `mcp.enabled: true` and repoint clients at the new `*-mcp` Service.

## Verification
- `go build ./...`, `go test ./...`, `golangci-lint run ./...` (0 issues)
- `helm lint` + `helm template` (default renders no MCP objects; MCP objects appear only with `mcp.enabled: true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)