### PR TITLE
feat(chart): add PDB + topology spread for the MCP workload

### DIFF
--- a/chart/cheshmhayash-chart/Chart.yaml
+++ b/chart/cheshmhayash-chart/Chart.yaml
@@ -4,7 +4,7 @@ description: NATS administration dashboard served over the NATS protocol itself.
 type: application
 
 # Chart version — bump on every chart change (independent of appVersion).
-version: 1.8.0
+version: 1.9.0
 
 # Application version — matches the cheshmhayash binary release. The
 # release.yaml workflow rewrites this to the pushed tag's version.
@@ -41,5 +41,7 @@ annotations:
     - name: nats.io
       url: https://nats.io
   artifacthub.io/changes: |
+    - kind: added
+      description: "The MCP workload now gets its own PodDisruptionBudget (`mcp.podDisruptionBudget`, rendered only when `mcp.replicaCount > 1`) and honours topology spread (`mcp.topologySpreadConstraints`, falling back to the top-level value) — availability parity with the dashboard."
     - kind: changed
       description: "The MCP server is now a separate binary (`cheshmhayash-mcp`); the dashboard no longer serves `/mcp`. Set `mcp.enabled: true` to run the Streamable HTTP transport as its own Deployment + Service (reuses the same image, settings.toml and NATS auth; `auth.mcp*` keys configure /mcp auth as before). Write tools gate on `mcp.write`."

--- a/chart/cheshmhayash-chart/templates/mcp-deployment.yaml
+++ b/chart/cheshmhayash-chart/templates/mcp-deployment.yaml
@@ -137,4 +137,15 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.mcp.topologySpreadConstraints | default .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range . }}
+        - maxSkew: {{ .maxSkew | default 1 }}
+          topologyKey: {{ .topologyKey | quote }}
+          whenUnsatisfiable: {{ .whenUnsatisfiable | default "ScheduleAnyway" }}
+          labelSelector:
+            matchLabels:
+              {{- include "cheshmhayash-chart.mcp.selectorLabels" $ | nindent 14 }}
+        {{- end }}
+      {{- end }}
 {{- end }}

--- a/chart/cheshmhayash-chart/templates/mcp-pdb.yaml
+++ b/chart/cheshmhayash-chart/templates/mcp-pdb.yaml
@@ -1,0 +1,24 @@
+{{- /*
+PodDisruptionBudget for the standalone MCP workload. Mirrors the dashboard
+pdb.yaml but selects the -mcp pods. The MCP Deployment has no HPA, so the
+effective replica count is simply mcp.replicaCount. Gated on > 1 because a
+minAvailable: 1 PDB on a single replica would block every voluntary eviction
+(node drains hang forever).
+*/}}
+{{- if and .Values.mcp.enabled .Values.mcp.podDisruptionBudget.enabled (gt (int .Values.mcp.replicaCount) 1) -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cheshmhayash-chart.mcp.fullname" . }}
+  labels:
+    {{- include "cheshmhayash-chart.mcp.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.mcp.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.mcp.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.mcp.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.mcp.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "cheshmhayash-chart.mcp.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/chart/cheshmhayash-chart/values.yaml
+++ b/chart/cheshmhayash-chart/values.yaml
@@ -155,6 +155,17 @@ mcp:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  # Spread MCP replicas across nodes/zones. Falls back to the top-level
+  # `topologySpreadConstraints` when empty; set to [] there too to disable.
+  topologySpreadConstraints: []
+  # Keep at least one MCP pod available during voluntary disruptions (node
+  # drains, rollouts). Only rendered when `mcp.replicaCount > 1` — a PDB with
+  # minAvailable: 1 on a single replica would block every drain.
+  podDisruptionBudget:
+    enabled: true
+    # Either minAvailable or maxUnavailable (mutually exclusive).
+    minAvailable: 1
+    # maxUnavailable: 1
 
 # --- ingress routing ------------------------------------------------------
 # The chart ships two ingress mechanisms; enable whichever fits your cluster.


### PR DESCRIPTION
## What

Gives the standalone MCP workload (`mcp.enabled`) the same availability protections the dashboard already has.

- **New `templates/mcp-pdb.yaml`** — a PodDisruptionBudget selecting the `-mcp` pods (distinct selector, never overlaps the dashboard PDB). Gated on **`mcp.replicaCount > 1`** so a `minAvailable: 1` PDB never blocks node drains on a single replica.
- **`mcp.topologySpreadConstraints`** — the MCP Deployment had none, so with `replicaCount: 2` both pods could schedule onto one node (defeating the PDB). Falls back to the top-level `topologySpreadConstraints` when empty (default: spread across `kubernetes.io/hostname`).
- **`mcp.podDisruptionBudget`** values block (`enabled: true`, `minAvailable: 1`).
- Chart `1.8.0` → `1.9.0`.

## Why

Before this, the new MCP Deployment was a single point of failure under node drains / co-scheduling — no parity with the dashboard.

## Verify

- `helm lint` clean.
- `mcp.enabled, replicaCount=2` → two PDBs (`*-mcp` + dashboard) + MCP topology spread.
- `replicaCount=1` → MCP PDB omitted (drain-safe); `podDisruptionBudget.enabled=false` → only dashboard PDB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)